### PR TITLE
docs(anchors): lock in greece + portugal residual diagnoses

### DIFF
--- a/docs/validation/greece.md
+++ b/docs/validation/greece.md
@@ -48,6 +48,10 @@ The 2024 backfill annual total for Greece is 0.802 TWh, which overreports by 129
 *   **Uniform Rate Across Years**: The 3.6% aggregate rate is applied uniformly across all backfilled years (2020–2026). While this is consistent with the backfill methodology for regions without documented per-year rate variants, it can lead to year-over-year drift compared to actual TSO figures as capacity mixes and operational conditions change.
 *   **Potential Reporting Latency**: As an ENTSO-E region, Greece may be subject to reporting-latency holes (1–3 month lag), which the backfill tolerates up to 10% per year.
 
+## v0.5 decision
+
+Documented as a residual outlier (+129.1%) under the §4.4 envelope-transparency principle; rate unchanged in v0.5. **v1 candidate** for Ember 2024–25 denominator refresh — see `docs/methodology/validation-discrepancies.md` row `greece` and `_provenance.haee-ipto-2024-annual.notes` in `scripts/validation/external-anchors.json`.
+
 ## Links
 
 - Loader source: _(no single-file loader — see multi-region source)_

--- a/docs/validation/portugal.md
+++ b/docs/validation/portugal.md
@@ -47,6 +47,10 @@ The backfill's 2024 annual total of 0.913 TWh for Portugal substantially overrep
 *   As a result, the backfill annual totals are derived from illustrative floor/ceiling values rather than measured annual calibration.
 *   See `docs/methodology/historical-backfill.md` §"Known limitations" for cross-cutting notes on the backfill approach.
 
+## v0.5 decision
+
+Documented as a residual outlier (+128.1%) under the §4.4 envelope-transparency principle; rate placeholder retained in v0.5. **v1 candidate** for REN 2024 Dados Técnicos / SEN bulletin scrape to ground-truth the rate — see `docs/methodology/validation-discrepancies.md` row `portugal` and `_provenance.ren-2024-annual.notes` in `scripts/validation/external-anchors.json`.
+
 ## Links
 
 - Loader source: _(no single-file loader — see multi-region source)_

--- a/scripts/validation/external-anchors.json
+++ b/scripts/validation/external-anchors.json
@@ -193,7 +193,8 @@
         "needs_url": true
       },
       "retrieved_at": "2026-04-26",
-      "retrieved_by": "gemini"
+      "retrieved_by": "gemini",
+      "notes": "v0.5 backfill reconstructs Portugal 2024 curtailment at 0.913 TWh, +128% vs this anchor's 0.400 TWh. Diagnosis: rate placeholder — 10% (solar) / 3% (wind) flagged in docs/methodology/entsoe-rates.md; no citable 2024 curtailed-energy total published by REN to ground-truth the rate against. Documented in docs/methodology/validation-discrepancies.md (Portugal row); Figure 2 row retained to document the gap. v1 candidate for REN 2024 Dados Técnicos / SEN bulletin scrape."
     },
     "mavir-2024-annual": {
       "title": "MAVIR Annual Report 2024",
@@ -336,7 +337,8 @@
         "needs_url": true
       },
       "retrieved_at": "2026-04-26",
-      "retrieved_by": "gemini"
+      "retrieved_by": "gemini",
+      "notes": "v0.5 backfill reconstructs Greece 2024 curtailment at 0.802 TWh, +129% vs this anchor's 0.350 TWh. Diagnosis: aggregate rate 3.6% grounded against HAEE 860 GWh (2023-era); Ember-2024 VRE denominator may underrepresent 2024 growth. Documented in docs/methodology/validation-discrepancies.md (Greece row); flagged as v1 candidate for Ember denominator refresh."
     },
     "hawaiian-2024-annual": {
       "title": "Hawaiian Annual Report 2024",


### PR DESCRIPTION
## Summary
- Adds `_provenance.notes` fields for `haee-ipto-2024-annual` and `ren-2024-annual` in `scripts/validation/external-anchors.json`, documenting the +129%/+128% Figure 2 residuals as rate-vs-anchor scope mismatches with v1-candidate paths cited.
- Adds explicit "v0.5 decision" sections to `docs/validation/greece.md` and `docs/validation/portugal.md` flagging both as v1 candidates under the §4.4 envelope-transparency principle. Per-region MDs now point back to the consolidated diagnosis in `docs/methodology/validation-discrepancies.md` and to the new `_provenance.notes`.
- Document-only edit. No rate change, no backfill regen, no schema migration. Closes the Greece + Portugal half of the decision request opened in PR #8.

## Why now
Phase-3 paper rewrite (PR #7) shipped with Figure 2 showing greece (+129%) and portugal (+128%) as residual outliers against published anchors. Those residuals are ALREADY accepted under §4.4's envelope-transparency principle; what was missing was a single source of truth in the anchor file itself — so a v1 author can grep `_provenance.*.notes` for "v1 candidate" and pick up the work without re-deriving the diagnosis.

This is the document-only path of PR #8; the iso-ne +284% case still requires a human-in-the-loop call (different category — TWh vs GWh unit-mismatch suspected, not a rate-scope mismatch) and is left out of scope here.

## CI gates
- `npm run typecheck` — green
- `npm run validate` — 75 snapshots / 110 records / 100% tier-enriched
- `npm run -s ci:tier-coherence` — coherent
- `npm run -s ci:tally-golden` — T1a=63 T1b=4 T1c=1 T2=2 T2-flare=4 T3=54 ✓
- `npm run -s ci:docs-drift` — all matched
- `npm test` — 83 files / 226 tests passing

## Test plan
- [x] CI gates locally green
- [ ] Vercel preview deploys cleanly (no public-surface change expected)
- [ ] CI workflow on PR passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)