### PR TITLE
Add Now chip: snap to current UTC and follow the wall clock

### DIFF
--- a/src/components/clock.js
+++ b/src/components/clock.js
@@ -12,6 +12,11 @@ export function createClock(initialHourUtc) {
     // to glance at the whole cycle at a go.
     speed: 0.5,
     playing: true,
+    // When true, the tick loop ignores `speed` and locks `hour` to the
+    // actual wall-clock UTC each frame (≈ 0.000278 h/s). Lets viewers
+    // watch the dashboard advance at "true" rate after scrubbing around.
+    // Any setSpeed/scrub interaction clears the flag automatically.
+    realTime: false,
     lastTs: null
   };
   const listeners = new Set();
@@ -23,15 +28,29 @@ export function createClock(initialHourUtc) {
     for (const fn of listeners) fn(state.hour);
   }
 
+  function utcNowHour() {
+    const d = new Date();
+    return d.getUTCHours()
+      + d.getUTCMinutes() / 60
+      + d.getUTCSeconds() / 3600
+      + d.getUTCMilliseconds() / 3_600_000;
+  }
+
   function tick(now) {
     if (!state.playing) {
       raf = null;
       return;
     }
-    const dt = state.lastTs == null ? 0 : (now - state.lastTs) / 1000;
+    if (state.realTime) {
+      // Pull from the wall clock each frame. Avoids dt drift from
+      // long pauses (background tabs, debugger stops).
+      state.hour = utcNowHour();
+    } else {
+      const dt = state.lastTs == null ? 0 : (now - state.lastTs) / 1000;
+      state.hour += 0.4 * state.speed * dt;
+      while (state.hour >= 24) state.hour -= 24;
+    }
     state.lastTs = now;
-    state.hour += 0.4 * state.speed * dt;
-    while (state.hour >= 24) state.hour -= 24;
     emit();
     raf = requestAnimationFrame(tick);
   }
@@ -52,6 +71,9 @@ export function createClock(initialHourUtc) {
     get speed() {
       return state.speed;
     },
+    get realTime() {
+      return state.realTime;
+    },
     subscribe(fn) {
       listeners.add(fn);
       fn(state.hour);
@@ -68,9 +90,28 @@ export function createClock(initialHourUtc) {
     },
     setSpeed(multiplier) {
       state.speed = multiplier;
+      // Picking a speed always means "I want synthetic playback at
+      // this rate", so we drop out of real-time tracking.
+      state.realTime = false;
     },
     scrub(hour) {
       state.hour = ((hour % 24) + 24) % 24;
+      // Manually positioning the clock is incompatible with the
+      // wall-clock lock — the next tick would overwrite us.
+      state.realTime = false;
+      emit();
+    },
+    enableRealTime() {
+      // Snap to actual UTC immediately so the UI doesn't have to wait
+      // for the first RAF frame, then ensure playback is running so
+      // the wall-clock branch in tick() keeps it in sync going forward.
+      state.realTime = true;
+      state.hour = utcNowHour();
+      state.lastTs = null;
+      if (!state.playing) {
+        state.playing = true;
+        start(true);
+      }
       emit();
     }
   };

--- a/src/components/controls.js
+++ b/src/components/controls.js
@@ -11,14 +11,29 @@ export function mountControls(container, clock) {
       ${[0.5, 1, 2, 4, 8].map((s) => `
         <button class="ctl-speed-chip${s === 0.5 ? " is-active" : ""}" data-speed="${s}">${s}×</button>
       `).join("")}
+      <button class="ctl-speed-chip ctl-speed-chip-now" data-now title="Snap to current UTC and follow the wall clock">Now</button>
     </div>
     <span class="ctl-utc num-tabular" aria-live="polite"></span>
   `;
 
   const playBtn = container.querySelector(".ctl-play");
   const playIcon = container.querySelector(".ctl-play-icon");
-  const chips = container.querySelectorAll(".ctl-speed-chip");
+  const speedChips = container.querySelectorAll(".ctl-speed-chip[data-speed]");
+  const nowChip = container.querySelector(".ctl-speed-chip[data-now]");
+  const allChips = container.querySelectorAll(".ctl-speed-chip");
   const utcEl = container.querySelector(".ctl-utc");
+
+  function syncChipActive() {
+    if (clock.realTime) {
+      allChips.forEach((c) => c.classList.toggle("is-active", c === nowChip));
+      return;
+    }
+    allChips.forEach((c) => {
+      const speedAttr = c.dataset.speed;
+      const isActive = speedAttr != null && Number(speedAttr) === clock.speed;
+      c.classList.toggle("is-active", isActive);
+    });
+  }
 
   function refreshPlayIcon() {
     // ⏸ (U+23F8) and ⏵ (U+23F5) are proper media-control glyphs that sit
@@ -34,12 +49,23 @@ export function mountControls(container, clock) {
     refreshPlayIcon();
   });
 
-  chips.forEach((chip) => {
+  speedChips.forEach((chip) => {
     chip.addEventListener("click", () => {
       const speed = Number(chip.dataset.speed);
       clock.setSpeed(speed);
-      chips.forEach((candidate) => candidate.classList.toggle("is-active", candidate === chip));
+      // setSpeed() clears clock.realTime as a side effect; re-sync chip
+      // states from the clock so the Now chip drops `is-active`.
+      syncChipActive();
     });
+  });
+
+  nowChip.addEventListener("click", () => {
+    clock.enableRealTime();
+    // enableRealTime() snaps the hour and emits, so the subscriber below
+    // will refresh the UTC readout. We still need to flip chip styling
+    // explicitly because clock state changes don't drive subscribers.
+    syncChipActive();
+    refreshPlayIcon();
   });
 
   clock.subscribe((hour) => {
@@ -47,7 +73,12 @@ export function mountControls(container, clock) {
     const mm = String(Math.floor((hour % 1) * 60)).padStart(2, "0");
     utcEl.textContent = `${hh}:${mm} UTC`;
     refreshPlayIcon();
+    // Timeline scrub or external setSpeed can clear realTime without going
+    // through these click handlers — keep chip styling in sync on every
+    // emit so the active state is always truthful.
+    syncChipActive();
   });
 
   refreshPlayIcon();
+  syncChipActive();
 }

--- a/tests/clock.test.ts
+++ b/tests/clock.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createClock } from "../src/components/clock.js";
+
+// The clock module spawns a requestAnimationFrame loop on construction.
+// jsdom polyfills RAF as a setTimeout(0) in some versions and not at all
+// in others; we stub it out so the integration loop never fires during
+// unit tests and `tick`-driven assertions only run when we explicitly
+// drive them. Each test that needs to advance the clock manually does so
+// by reading the clock's exported helpers — we never assert against the
+// internal RAF schedule.
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", () => 0);
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createClock - real-time mode", () => {
+  it("starts with realTime disabled by default", () => {
+    const clock = createClock(12);
+    expect(clock.realTime).toBe(false);
+  });
+
+  it("enableRealTime() snaps clock.hour to the current UTC hour", () => {
+    const clock = createClock(0);
+    // Pin a deterministic moment: 2026-04-27 14:30:30 UTC ≈ 14.508333 hours.
+    const fixed = Date.UTC(2026, 3, 27, 14, 30, 30);
+    vi.setSystemTime(new Date(fixed));
+    clock.enableRealTime();
+    expect(clock.realTime).toBe(true);
+    expect(clock.hour).toBeCloseTo(14 + 30 / 60 + 30 / 3600, 5);
+    vi.useRealTimers();
+  });
+
+  it("setSpeed() exits real-time mode", () => {
+    const clock = createClock(0);
+    clock.enableRealTime();
+    expect(clock.realTime).toBe(true);
+    clock.setSpeed(2);
+    expect(clock.realTime).toBe(false);
+    expect(clock.speed).toBe(2);
+  });
+
+  it("scrub() exits real-time mode", () => {
+    const clock = createClock(0);
+    clock.enableRealTime();
+    expect(clock.realTime).toBe(true);
+    clock.scrub(8);
+    expect(clock.realTime).toBe(false);
+    expect(clock.hour).toBe(8);
+  });
+
+  it("calling enableRealTime() resumes playing if previously paused", () => {
+    const clock = createClock(0);
+    clock.pause();
+    expect(clock.playing).toBe(false);
+    clock.enableRealTime();
+    expect(clock.playing).toBe(true);
+    expect(clock.realTime).toBe(true);
+  });
+
+  it("subscribers receive the snapped hour on enableRealTime()", () => {
+    const clock = createClock(0);
+    const fixed = Date.UTC(2026, 3, 27, 9, 0, 0);
+    vi.setSystemTime(new Date(fixed));
+    let received: number | null = null;
+    // subscribe fires immediately with current hour, so reset before enabling
+    const unsubscribe = clock.subscribe((h) => { received = h; });
+    received = null;
+    clock.enableRealTime();
+    expect(received).toBeCloseTo(9, 5);
+    unsubscribe();
+    vi.useRealTimers();
+  });
+});

--- a/tests/clock.test.ts
+++ b/tests/clock.test.ts
@@ -69,7 +69,7 @@ describe("createClock - real-time mode", () => {
     vi.setSystemTime(new Date(fixed));
     let received: number | null = null;
     // subscribe fires immediately with current hour, so reset before enabling
-    const unsubscribe = clock.subscribe((h) => { received = h; });
+    const unsubscribe = clock.subscribe((h: number) => { received = h; });
     received = null;
     clock.enableRealTime();
     expect(received).toBeCloseTo(9, 5);


### PR DESCRIPTION
## Summary
- Adds a "Now" chip to the playback control row (next to 0.5× / 1× / 2× / 4× / 8×)
- Click "Now" → clock snaps to current UTC and starts following the wall clock at real rate (1 real second = 1 UTC second of advance)
- Click any speed chip → exits real-time mode, resumes synthetic playback at that speed
- Scrubbing the timeline manually exits real-time mode (consistent with how scrubbing already pauses)
- Pause/play preserves real-time mode: pause freezes the readout; play re-snaps to *then-current* UTC so leaving the tab parked doesn't desync

## Why
Today the clock starts at the page-load UTC and then plays back at synthetic speeds. After scrubbing around there's no clean way back to "what's actually happening right now" — and even if you nudge it manually, the synthetic 0.4 h/s base rate means the displayed UTC drifts away from real wall-clock immediately. The "Now" chip is the missing transport control.

## What changed
- `src/components/clock.js` — new `state.realTime` flag, `enableRealTime()` api, wall-clock branch in `tick()` (`state.hour = utcNowHour()` each frame, no dt integration). `setSpeed()` and `scrub()` clear the flag automatically.
- `src/components/controls.js` — extra chip + click handler, chip-state syncing on every clock emit so external state changes (timeline scrub, programmatic setSpeed) keep the active chip styling truthful.
- `tests/clock.test.ts` — new file, 6 unit tests covering `enableRealTime`, the flag-clearing behaviour of `setSpeed` and `scrub`, paused-then-realtime resume, and subscriber notification with the snapped hour.

No CSS changes — reuses existing `.ctl-speed-chip` styling, so the active state visual matches the speed chips.

## Branch base
Branched off `v0-build` (kept independent of the in-flight theme PR #14 for review hygiene).

## Test plan
- [x] `vitest run` — all 232 tests pass (6 new clock tests added)
- [x] Click "Now" → readout snaps to current UTC, "Now" chip gets active state
- [x] Click 4× while in real-time → exits real-time, 4× becomes active, "Now" deactivates
- [x] Pause then resume while in real-time → readout re-snaps to current UTC and continues
- [ ] Manual: leave a tab parked for >1 minute in real-time mode, return — readout should match wall clock, not be 1 minute behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)