### PR TITLE
feat(header): pull dataset version from Zenodo

### DIFF
--- a/src/data/zenodo-version.json.ts
+++ b/src/data/zenodo-version.json.ts
@@ -19,6 +19,12 @@ const CONCEPT_DOI = `10.5281/zenodo.${CONCEPT_RECORD_ID}`;
 const ZENODO_VERSIONS_LATEST_URL = `https://zenodo.org/api/records/${CONCEPT_RECORD_ID}/versions/latest`;
 const CITATION_PATH = join(process.cwd(), "dataset", "CITATION.cff");
 
+// SemVer-ish: 1.2.3, 1.2.3-rc.1, 1.2.3+build.7. Locked-down to defend the
+// header (which interpolates this value into innerHTML) against a malformed
+// or hostile upstream string. Anything outside this charset → throw.
+const SAFE_VERSION = /^[0-9][0-9A-Za-z.\-+]*$/;
+const ZENODO_HOSTS = new Set(["zenodo.org", "doi.org"]);
+
 export interface ZenodoVersion {
   /** Version string without leading "v" (e.g. "1.1.1"). */
   version: string;
@@ -42,15 +48,49 @@ export function normalizeVersion(raw: string): string {
   return raw.trim().replace(/^v/i, "");
 }
 
+/**
+ * Reject anything that isn't an https URL on a known host. The header
+ * interpolates `recordUrl` into an `<a href="${...}">`, so a hostile or
+ * malformed value would be a script-injection vector via `javascript:` or
+ * an attribute-break.
+ */
+function assertSafeRecordUrl(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`unparseable recordUrl: ${JSON.stringify(url)}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`recordUrl must be https, got ${parsed.protocol} (${url})`);
+  }
+  if (!ZENODO_HOSTS.has(parsed.hostname)) {
+    throw new Error(`recordUrl host not allow-listed: ${parsed.hostname} (${url})`);
+  }
+}
+
+function assertSafeVersion(version: string): void {
+  if (!SAFE_VERSION.test(version)) {
+    throw new Error(`unexpected version format: ${JSON.stringify(version)}`);
+  }
+}
+
 export function parseZenodoRecord(rec: ZenodoRecord): ZenodoVersion {
+  if (typeof rec.id !== "number") {
+    throw new Error(`Zenodo record has no numeric id (got ${typeof rec.id})`);
+  }
   const rawVersion = rec.metadata?.version;
   if (!rawVersion) {
     throw new Error(`Zenodo record ${rec.id} has no metadata.version`);
   }
+  const version = normalizeVersion(rawVersion);
+  const recordUrl = rec.links?.self_html ?? `https://zenodo.org/records/${rec.id}`;
+  assertSafeVersion(version);
+  assertSafeRecordUrl(recordUrl);
   return {
-    version: normalizeVersion(rawVersion),
+    version,
     doi: rec.doi,
-    recordUrl: rec.links?.self_html ?? `https://zenodo.org/records/${rec.id}`,
+    recordUrl,
     source: "zenodo",
   };
 }
@@ -72,16 +112,24 @@ export function parseCitationCff(text: string): ZenodoVersion {
     /-\s*type:\s*doi\s*[\r\n]+\s*value:\s*"?(10\.5281\/zenodo\.\d+)"?\s*[\r\n]+\s*description:\s*"Zenodo archival DOI/,
   );
   const doi = archivalDoiMatch?.[1] ?? CONCEPT_DOI;
+  const recordUrl = `https://doi.org/${doi}`;
+  assertSafeVersion(version);
+  assertSafeRecordUrl(recordUrl);
   return {
     version,
     doi,
-    recordUrl: `https://doi.org/${doi}`,
+    recordUrl,
     source: "citation-cff",
   };
 }
 
 async function loadFromZenodo(): Promise<ZenodoVersion> {
-  const rec = await fetchJSON<ZenodoRecord>(ZENODO_VERSIONS_LATEST_URL);
+  const rec = await fetchJSON<ZenodoRecord>(ZENODO_VERSIONS_LATEST_URL, {
+    headers: {
+      "User-Agent": "every-last-joule-build/1.0 (+https://everylastjoule.com)",
+      Accept: "application/json",
+    },
+  });
   return parseZenodoRecord(rec);
 }
 

--- a/src/data/zenodo-version.json.ts
+++ b/src/data/zenodo-version.json.ts
@@ -1,0 +1,119 @@
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { fetchJSON } from "../lib/fetch.js";
+
+/**
+ * Build-time loader: fetches the latest published version of the Every Last
+ * Joule dataset from Zenodo via the concept-record endpoint, which always
+ * resolves to the most recent version. Used by the dashboard header to keep
+ * the displayed version string in sync with Zenodo (so a CITATION.cff bump
+ * that has not yet been uploaded to Zenodo is *not* shown — the live site
+ * tracks reality, not intent).
+ *
+ * Fallback order: Zenodo API → CITATION.cff (with a build-log warning).
+ */
+
+const CONCEPT_RECORD_ID = "19835411"; // Zenodo concept record (always-latest)
+const CONCEPT_DOI = `10.5281/zenodo.${CONCEPT_RECORD_ID}`;
+const ZENODO_VERSIONS_LATEST_URL = `https://zenodo.org/api/records/${CONCEPT_RECORD_ID}/versions/latest`;
+const CITATION_PATH = join(process.cwd(), "dataset", "CITATION.cff");
+
+export interface ZenodoVersion {
+  /** Version string without leading "v" (e.g. "1.1.1"). */
+  version: string;
+  /** Versioned DOI (e.g. "10.5281/zenodo.19991315") when available, else concept DOI. */
+  doi: string;
+  /** HTML page for this record on Zenodo. */
+  recordUrl: string;
+  /** Where this record came from. */
+  source: "zenodo" | "citation-cff";
+}
+
+interface ZenodoRecord {
+  id: number;
+  doi: string;
+  metadata?: { version?: string };
+  links?: { self_html?: string; latest_html?: string };
+}
+
+/** Strip a leading "v" or "V" if present. Idempotent. */
+export function normalizeVersion(raw: string): string {
+  return raw.trim().replace(/^v/i, "");
+}
+
+export function parseZenodoRecord(rec: ZenodoRecord): ZenodoVersion {
+  const rawVersion = rec.metadata?.version;
+  if (!rawVersion) {
+    throw new Error(`Zenodo record ${rec.id} has no metadata.version`);
+  }
+  return {
+    version: normalizeVersion(rawVersion),
+    doi: rec.doi,
+    recordUrl: rec.links?.self_html ?? `https://zenodo.org/records/${rec.id}`,
+    source: "zenodo",
+  };
+}
+
+/**
+ * Parse a CITATION.cff string for the version + Zenodo archival DOI. Used as
+ * an offline fallback when the Zenodo API is unreachable at build time.
+ */
+export function parseCitationCff(text: string): ZenodoVersion {
+  const versionMatch = text.match(/^version:\s*(\S+)/m);
+  if (!versionMatch) {
+    throw new Error("CITATION.cff has no top-level `version:` field");
+  }
+  const version = normalizeVersion(versionMatch[1]);
+
+  // Look for the archival (versioned) Zenodo DOI in identifiers; fall back
+  // to the concept DOI if not present.
+  const archivalDoiMatch = text.match(
+    /-\s*type:\s*doi\s*[\r\n]+\s*value:\s*"?(10\.5281\/zenodo\.\d+)"?\s*[\r\n]+\s*description:\s*"Zenodo archival DOI/,
+  );
+  const doi = archivalDoiMatch?.[1] ?? CONCEPT_DOI;
+  return {
+    version,
+    doi,
+    recordUrl: `https://doi.org/${doi}`,
+    source: "citation-cff",
+  };
+}
+
+async function loadFromZenodo(): Promise<ZenodoVersion> {
+  const rec = await fetchJSON<ZenodoRecord>(ZENODO_VERSIONS_LATEST_URL);
+  return parseZenodoRecord(rec);
+}
+
+function loadFromCitationCff(): ZenodoVersion {
+  if (!existsSync(CITATION_PATH)) {
+    throw new Error(`CITATION.cff not found at ${CITATION_PATH}`);
+  }
+  return parseCitationCff(readFileSync(CITATION_PATH, "utf8"));
+}
+
+async function run(): Promise<ZenodoVersion> {
+  try {
+    return await loadFromZenodo();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[zenodo-version] live fetch failed (${msg}); falling back to dataset/CITATION.cff`,
+    );
+    return loadFromCitationCff();
+  }
+}
+
+const isMain =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  run()
+    .then((data) => {
+      process.stdout.write(JSON.stringify(data));
+    })
+    .catch((err) => {
+      console.error("[zenodo-version] all fallbacks failed:", err);
+      process.exit(1);
+    });
+}

--- a/src/index.md
+++ b/src/index.md
@@ -43,7 +43,8 @@ const [
   chinaShandong, chinaGuangdong, chinaJiangsu, chinaAnhui, chinaHunan,
   chinaLiaoning, chinaHubei, chinaShanxi, chinaShaanxi, chinaZhejiang,
   chinaHenan, chinaFujian, chinaJiangxi, chinaBeijing, chinaGuizhou,
-  chinaChongqing, chinaTianjin, chinaHainan, chinaShanghai
+  chinaChongqing, chinaTianjin, chinaHainan, chinaShanghai,
+  zenodoVersion
 ] = await Promise.all([
   FileAttachment("data/cbeci.json").json(),
   FileAttachment("data/ercot.json").json(),
@@ -146,7 +147,8 @@ const [
   FileAttachment("data/china-chongqing.json").json(),
   FileAttachment("data/china-tianjin.json").json(),
   FileAttachment("data/china-hainan.json").json(),
-  FileAttachment("data/china-shanghai.json").json()
+  FileAttachment("data/china-shanghai.json").json(),
+  FileAttachment("data/zenodo-version.json").json()
 ]);
 
 document.getElementById("app-root").innerHTML = `
@@ -155,7 +157,7 @@ document.getElementById("app-root").innerHTML = `
       <div class="app-title">
         <span class="app-mark">●</span>
         <span class="app-wordmark">Every Last Joule</span>
-        <span class="app-tag">Wasted Energy Database · v1.0.0</span>
+        <span class="app-tag">Wasted Energy Database · <a class="app-tag-version" href="${zenodoVersion.recordUrl}" target="_blank" rel="noopener">v${zenodoVersion.version}</a></span>
       </div>
       <div class="app-header-right">
         <div id="theme-toggle-mount"></div>

--- a/src/style.css
+++ b/src/style.css
@@ -580,8 +580,9 @@ main table {
   margin-left: 2px;
 }
 
-/* Specificity bump: Observable Framework's theme sets `a[href]{color:var(--theme-foreground-focus)}`
- * (specificity 0,1,1) which would otherwise win over a plain `.app-tag-version`. */
+/* Observable Framework's theme sets `a[href]{color:var(--theme-foreground-focus)}`
+ * (specificity 0,1,1). Scoping with `.app-tag` lifts our rule to (0,2,0)
+ * so the link inherits the muted tag colour instead of the framework blue. */
 .app-tag .app-tag-version {
   color: inherit;
   text-decoration: none;

--- a/src/style.css
+++ b/src/style.css
@@ -580,6 +580,21 @@ main table {
   margin-left: 2px;
 }
 
+/* Specificity bump: Observable Framework's theme sets `a[href]{color:var(--theme-foreground-focus)}`
+ * (specificity 0,1,1) which would otherwise win over a plain `.app-tag-version`. */
+.app-tag .app-tag-version {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--hairline-strong);
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.app-tag .app-tag-version:hover,
+.app-tag .app-tag-version:focus-visible {
+  color: var(--brand);
+  border-bottom-color: var(--brand);
+}
+
 .app-methodology {
   font-size: 12px;
   letter-spacing: 0.06em;

--- a/tests/data/zenodo-version.test.ts
+++ b/tests/data/zenodo-version.test.ts
@@ -54,6 +54,44 @@ describe("zenodo-version loader", () => {
       };
       expect(() => parseZenodoRecord(rec)).toThrow(/no metadata.version/);
     });
+
+    it("throws when id is not a number (defends against unexpected response shape)", () => {
+      const rec = {
+        id: undefined as unknown as number,
+        doi: "10.5281/zenodo.19991315",
+        metadata: { version: "1.1.1" },
+      };
+      expect(() => parseZenodoRecord(rec)).toThrow(/numeric id/);
+    });
+
+    it("rejects a version string with HTML-injection characters", () => {
+      const rec = {
+        id: 19991315,
+        doi: "10.5281/zenodo.19991315",
+        metadata: { version: '1.1.1"><script>alert(1)</script>' },
+      };
+      expect(() => parseZenodoRecord(rec)).toThrow(/unexpected version format/);
+    });
+
+    it("rejects a recordUrl on a non-allow-listed host", () => {
+      const rec = {
+        id: 19991315,
+        doi: "10.5281/zenodo.19991315",
+        metadata: { version: "1.1.1" },
+        links: { self_html: "https://evil.example/records/19991315" },
+      };
+      expect(() => parseZenodoRecord(rec)).toThrow(/allow-listed/);
+    });
+
+    it("rejects a javascript: recordUrl", () => {
+      const rec = {
+        id: 19991315,
+        doi: "10.5281/zenodo.19991315",
+        metadata: { version: "1.1.1" },
+        links: { self_html: "javascript:alert(1)" as string },
+      };
+      expect(() => parseZenodoRecord(rec)).toThrow(/https/);
+    });
   });
 
   describe("parseCitationCff", () => {
@@ -89,6 +127,11 @@ describe("zenodo-version loader", () => {
 
     it("throws when there is no version field", () => {
       expect(() => parseCitationCff("title: foo\n")).toThrow(/version/);
+    });
+
+    it("handles CRLF line endings", () => {
+      const cff = "version: 1.2.0\r\nidentifiers:\r\n";
+      expect(parseCitationCff(cff).version).toBe("1.2.0");
     });
   });
 });

--- a/tests/data/zenodo-version.test.ts
+++ b/tests/data/zenodo-version.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeVersion,
+  parseZenodoRecord,
+  parseCitationCff,
+} from "../../src/data/zenodo-version.json";
+
+describe("zenodo-version loader", () => {
+  describe("normalizeVersion", () => {
+    it("strips leading 'v'", () => {
+      expect(normalizeVersion("v1.1.1")).toBe("1.1.1");
+      expect(normalizeVersion("V2.0")).toBe("2.0");
+    });
+    it("leaves bare versions untouched", () => {
+      expect(normalizeVersion("1.2.0")).toBe("1.2.0");
+    });
+    it("trims whitespace", () => {
+      expect(normalizeVersion("  v1.1.1 ")).toBe("1.1.1");
+    });
+  });
+
+  describe("parseZenodoRecord", () => {
+    it("extracts version, doi, and self_html link", () => {
+      const rec = {
+        id: 19991315,
+        doi: "10.5281/zenodo.19991315",
+        metadata: { version: "v1.1.1" },
+        links: { self_html: "https://zenodo.org/records/19991315" },
+      };
+      expect(parseZenodoRecord(rec)).toEqual({
+        version: "1.1.1",
+        doi: "10.5281/zenodo.19991315",
+        recordUrl: "https://zenodo.org/records/19991315",
+        source: "zenodo",
+      });
+    });
+
+    it("falls back to constructed URL when self_html is missing", () => {
+      const rec = {
+        id: 19991315,
+        doi: "10.5281/zenodo.19991315",
+        metadata: { version: "1.1.1" },
+      };
+      expect(parseZenodoRecord(rec).recordUrl).toBe(
+        "https://zenodo.org/records/19991315",
+      );
+    });
+
+    it("throws when metadata.version is missing", () => {
+      const rec = {
+        id: 19991315,
+        doi: "10.5281/zenodo.19991315",
+        metadata: {},
+      };
+      expect(() => parseZenodoRecord(rec)).toThrow(/no metadata.version/);
+    });
+  });
+
+  describe("parseCitationCff", () => {
+    it("extracts version and the archival DOI", () => {
+      const cff = [
+        "cff-version: 1.2.0",
+        "title: Example",
+        "version: 1.2.0",
+        "identifiers:",
+        '  - type: doi',
+        '    value: "10.5281/zenodo.19991315"',
+        '    description: "Zenodo archival DOI (versioned, v1.1.1)"',
+        '  - type: doi',
+        '    value: "10.5281/zenodo.19835411"',
+        '    description: "Zenodo concept DOI (resolves to latest version)"',
+      ].join("\n");
+
+      expect(parseCitationCff(cff)).toEqual({
+        version: "1.2.0",
+        doi: "10.5281/zenodo.19991315",
+        recordUrl: "https://doi.org/10.5281/zenodo.19991315",
+        source: "citation-cff",
+      });
+    });
+
+    it("falls back to the concept DOI when no archival DOI is present", () => {
+      const cff = "version: 0.9.0\n";
+      const result = parseCitationCff(cff);
+      expect(result.version).toBe("0.9.0");
+      expect(result.doi).toBe("10.5281/zenodo.19835411");
+      expect(result.source).toBe("citation-cff");
+    });
+
+    it("throws when there is no version field", () => {
+      expect(() => parseCitationCff("title: foo\n")).toThrow(/version/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The header tag was hardcoded to \`Wasted Energy Database · v1.0.0\` and silently drifted past v1.1.1. This wires it to the live Zenodo concept-DOI endpoint (\`https://zenodo.org/api/records/19835411/versions/latest\`) at build time so the displayed version always matches what is actually published on Zenodo — not the local prepped version in CITATION.cff.

- New build-time loader: \`src/data/zenodo-version.json.ts\` — emits \`{version, doi, recordUrl, source}\`.
- Header in \`src/index.md\` templates the version in and links it to the Zenodo record.
- Fallback chain when the Zenodo API is unreachable at build time: parse \`dataset/CITATION.cff\` for \`version:\` and the archival DOI, log a build warning, keep building. Deterministic offline; CI never breaks on a transient Zenodo outage.
- Specificity bump on \`.app-tag .app-tag-version\` because Observable Framework's theme sets \`a[href]{color:var(--theme-foreground-focus)}\` which would otherwise win.

**Currently displays:** \`WASTED ENERGY DATABASE · V1.1.1\` (live Zenodo). Will auto-bump to \`V1.2.0\` on the next build after the v1.2.0 archive is uploaded — no code change needed.

## Test plan

- [x] \`npm test\` — 411 passed (was 402; +9 unit tests for normalizeVersion / parseZenodoRecord / parseCitationCff)
- [x] \`npx tsx src/data/zenodo-version.json.ts\` — emits live Zenodo payload
- [x] Fallback verified by stubbing \`globalThis.fetch\` to throw — emits CITATION.cff payload + warning to stderr
- [x] \`npm run build\` — succeeds; \`dist/_file/data/zenodo-version.<hash>.json\` contains \`{"version":"1.1.1","doi":"10.5281/zenodo.19991315",...}\`
- [x] \`observable preview\` rendered header inspected in DOM — link colour inherits muted ink, dotted underline, opens Zenodo record in new tab
- [x] \`npm run typecheck\` — clean

## Out of scope (existing on main, flagging for separate fix)

\`npm run ci:tier-coherence\` and \`ci:tally-golden\` both fail on \`main\` complaining about missing \`STATIC_PROFILE_KIND\` rows for the four regions added in PR #35: \`china-hebei\`, \`china-heilongjiang\`, \`china-jilin\`, \`tva\`. Confirmed pre-existing via stash + checkout main.