### PR TITLE
chore(pre-launch): unblock CI tier-coherence + sweep stale region counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Every Last Joule
 
-Hourly renewable-electricity curtailment and associated-gas flaring across **128 regions** on six continents. Live dashboard at **[everylastjoule.com](https://everylastjoule.com)**.
+Hourly renewable-electricity curtailment and associated-gas flaring across **241 regions** on six continents. Live dashboard at **[everylastjoule.com](https://everylastjoule.com)**.
 
 This repository contains both the published dataset (the academic artefact) and the dashboard build that produces it (the engineering artefact).
 
@@ -14,7 +14,7 @@ This repository contains both the published dataset (the academic artefact) and 
 
 ## What this dataset is
 
-A versioned, reproducible synthesis of hourly curtailment series, with **per-region provenance, calibration rate, and confidence tier** on every emitted row. The 233 regions break down as **106 T1a-live-tso** (live hourly feed + own-jurisdiction calibration rate), **6 T1b-live-domestic-anchored** (Italy-Sardinia, Italy-North-Zone, Italy-Sicily, Netherlands, Baltics, Colombia — live feed + domestic-stat-agency or modelled-share rate), **1 T1c-live-neighbour-anchored** (Switzerland — Swissgrid live feed against the Czech CEPS rate), **2 T2-annual-calibrated** (flat-base statics anchored to a published annual), **4 T2-flare** (24/7 base-load, methodologically correct for flare), and **114 T3-modelled** (typical diurnal/seasonal/mixed/overnight shape scaled to a published annual anchor). Authoritative tally: `npm run tally:tiers`.
+A versioned, reproducible synthesis of hourly curtailment series, with **per-region provenance, calibration rate, and confidence tier** on every emitted row. The 241 regions break down across the T1a/T1b/T1c (live), T2 / T2-flare (annual-calibrated), and T3 (modelled) tiers — run `npm run tally:tiers` for the authoritative current breakdown and per-bucket region list.
 
 A seven-year hourly reconstruction (2020-01-01 → 2026-04-24, **2,590,195 rows × 29 regions**) is published alongside the live snapshots in [`data/historical/curtailment_backfill.parquet`](data/historical/). Methodology in [`docs/methodology/historical-backfill.md`](docs/methodology/historical-backfill.md).
 
@@ -25,7 +25,7 @@ Requires Node 20 (`nvm use`).
     npm install            # install deps
     npm run dev            # local Observable Framework preview
     npm run build          # produce a static dist/
-    npm test               # vitest unit tests (205 across 82 files)
+    npm test               # vitest unit tests
     npm run typecheck      # tsc --noEmit
     npm run validate       # validate every committed snapshot against the schema
     npm run tally:tiers    # print the canonical T1 / T2 / T2-flare / T3 tally
@@ -50,7 +50,7 @@ Live data loaders need free upstream API tokens (`ENTSOE_TOKEN`, `EIA_API_KEY`, 
 
 ## Citation
 
-> Collins, S. (2026). _Every Last Joule: an hourly synthesis of renewable-electricity curtailment and associated-gas flaring across 128 regions._ Scientific Data (in review). Dataset DOI: [10.5281/zenodo.19835566](https://doi.org/10.5281/zenodo.19835566).
+> Collins, S. (2026). _Every Last Joule: an hourly synthesis of renewable-electricity curtailment and associated-gas flaring across 241 regions._ Scientific Data (in review). Dataset DOI: [10.5281/zenodo.19991315](https://doi.org/10.5281/zenodo.19991315) (concept DOI [10.5281/zenodo.19835411](https://doi.org/10.5281/zenodo.19835411) resolves to latest).
 
 Machine-readable: [`dataset/CITATION.cff`](dataset/CITATION.cff).
 

--- a/dataset/README.md
+++ b/dataset/README.md
@@ -56,7 +56,7 @@ print(snap["peakGW"], snap["sourceStatus"], snap["lastUpdated"])
 
 If you use this dataset in academic work, please cite:
 
-> Collins, S. (2026). Every Last Joule: an hourly synthesis of renewable-electricity curtailment and associated-gas flaring across 233 regions. _Scientific Data_ (in review). Dataset DOI: [10.5281/zenodo.19991315](https://doi.org/10.5281/zenodo.19991315).
+> Collins, S. (2026). Every Last Joule: an hourly synthesis of renewable-electricity curtailment and associated-gas flaring across 241 regions. _Scientific Data_ (in review). Dataset DOI: [10.5281/zenodo.19991315](https://doi.org/10.5281/zenodo.19991315).
 
 Machine-readable citation metadata in [`CITATION.cff`](CITATION.cff).
 

--- a/dataset/SCHEMA.md
+++ b/dataset/SCHEMA.md
@@ -59,7 +59,7 @@ Location: `data/historical/curtailment_history.parquet`
 
 One row per region per successful scheduled build. Appended by `scripts/append_history.py` via `.github/workflows/history-append.yml` (daily at 02:00 UTC plus on every successful refresh).
 
-Compression: Snappy. Format: Parquet 2.6. Typical size: ~100 bytes per row × 233 regions × ~4 builds/day ≈ **34 MB / year**.
+Compression: Snappy. Format: Parquet 2.6. Typical size: ~100 bytes per row × 241 regions × ~4 builds/day ≈ **35 MB / year**.
 
 ### Columns
 

--- a/docs/paper/01-background-and-summary.md
+++ b/docs/paper/01-background-and-summary.md
@@ -76,7 +76,7 @@ The dataset is organised on two orthogonal axes (full taxonomy:
 
 | | `published` | `documented-gap` | `out-of-scope` |
 |---|---|---|---|
-| **`curtailment-renewable`** | 233 regions: live ENTSO-E/EIA/AEMO/Elexon/etc.; T2 calibrated; T3 modelled. | Mexico CENACE, parts of SE Asia, Iran solar… (see `docs/known-limitations.md`) | Antarctica, Vatican, Greenland (~all baseload thermal/diesel) |
+| **`curtailment-renewable`** | 241 regions: live ENTSO-E/EIA/AEMO/Elexon/etc.; T2 calibrated; T3 modelled. | Mexico CENACE, parts of SE Asia, Iran solar… (see `docs/known-limitations.md`) | Antarctica, Vatican, Greenland (~all baseload thermal/diesel) |
 | **`flare-associated-gas`** | 8 regions: Permian, West Siberia, South Iraq, East Saudi Arabia, Qatar, Kuwait, Russia Yamal-Nenets, Russia East Siberia. | Iran flaring (no GGFR-equivalent disaggregation). | Small flares < 1 Bcm/yr |
 
 Three aspects set this work apart:

--- a/docs/paper/every-last-joule-scientific-data-draft.md
+++ b/docs/paper/every-last-joule-scientific-data-draft.md
@@ -76,7 +76,7 @@ The dataset is organised on two orthogonal axes (full taxonomy:
 
 | | `published` | `documented-gap` | `out-of-scope` |
 |---|---|---|---|
-| **`curtailment-renewable`** | 233 regions: live ENTSO-E/EIA/AEMO/Elexon/etc.; T2 calibrated; T3 modelled. | Mexico CENACE, parts of SE Asia, Iran solar… (see `docs/known-limitations.md`) | Antarctica, Vatican, Greenland (~all baseload thermal/diesel) |
+| **`curtailment-renewable`** | 241 regions: live ENTSO-E/EIA/AEMO/Elexon/etc.; T2 calibrated; T3 modelled. | Mexico CENACE, parts of SE Asia, Iran solar… (see `docs/known-limitations.md`) | Antarctica, Vatican, Greenland (~all baseload thermal/diesel) |
 | **`flare-associated-gas`** | 8 regions: Permian, West Siberia, South Iraq, East Saudi Arabia, Qatar, Kuwait, Russia Yamal-Nenets, Russia East Siberia. | Iran flaring (no GGFR-equivalent disaggregation). | Small flares < 1 Bcm/yr |
 
 Three aspects set this work apart:

--- a/observablehq.config.ts
+++ b/observablehq.config.ts
@@ -13,7 +13,7 @@ const SITE_URL = "https://everylastjoule.com";
 const OG_IMAGE = `${SITE_URL}/og-image.png`;
 const OG_TITLE = "Every Last Joule";
 const OG_DESCRIPTION =
-  "The wasted-energy database: curtailed renewables and flared gas across 128 regions worldwide, live from grid operators. How much of Bitcoin's hashrate could run on the joules we already pay for but throw away?";
+  "The wasted-energy database: curtailed renewables and flared gas across 241 regions worldwide, live from grid operators. How much of Bitcoin's hashrate could run on the joules we already pay for but throw away?";
 
 const socialMeta = [
   `<meta name="description" content="${OG_DESCRIPTION}">`,
@@ -24,7 +24,7 @@ const socialMeta = [
   `<meta property="og:image" content="${OG_IMAGE}">`,
   `<meta property="og:image:width" content="1200">`,
   `<meta property="og:image:height" content="630">`,
-  `<meta property="og:image:alt" content="Globe showing wasted-energy pillars — curtailed renewables and flared gas — across 128 regions; headline reads 241% of Bitcoin hashrate supportable on the joules we already throw away.">`,
+  `<meta property="og:image:alt" content="Globe showing wasted-energy pillars — curtailed renewables and flared gas — across 241 regions; headline reads 241% of Bitcoin hashrate supportable on the joules we already throw away.">`,
   `<meta name="twitter:card" content="summary_large_image">`,
   `<meta name="twitter:title" content="${OG_TITLE}">`,
   `<meta name="twitter:description" content="${OG_DESCRIPTION}">`,

--- a/scripts/lib/tier-resolution.ts
+++ b/scripts/lib/tier-resolution.ts
@@ -60,12 +60,17 @@ export const STATIC_PROFILE_KIND: Record<string, ProfileKind> = {
   "china-tianjin": "mixed",
   "china-hainan": "solar",
   "china-shanghai": "solar",
+  // China W3 (Phase-2.7, 2026-05-03): northeast wind-corridor provinces.
+  "china-hebei": "wind",
+  "china-heilongjiang": "wind",
+  "china-jilin": "wind",
   iceland: "hydro-seasonal",
   ukraine: "solar",
   "hawaii-oahu": "solar",
   "hawaii-maui": "solar",
   "hawaii-island": "solar",
   florida: "solar",
+  tva: "solar",
   austria: "flat",
   "russia-murmansk-wind": "flat",
   // typical-shape loaders

--- a/src/about.md
+++ b/src/about.md
@@ -8,7 +8,7 @@
 
 # A measured working model, not a branding exercise
 
-<p class="methodology-deck">The world's most comprehensive open database of wasted grid-scale energy — curtailed renewables and flared gas across 128 regions — and a live working proof of the arithmetic in a forthcoming book on Bitcoin and energy. Updated every few hours, sourced exclusively from grid operators and regulators.</p>
+<p class="methodology-deck">The world's most comprehensive open database of wasted grid-scale energy — curtailed renewables and flared gas across 241 regions — and a live working proof of the arithmetic in a forthcoming book on Bitcoin and energy. Updated every few hours, sourced exclusively from grid operators and regulators.</p>
 
 </header>
 


### PR DESCRIPTION
Pre-launch mop-up ahead of the everylastjoule.com soft launch.

## Changes (two commits)

**\`c16aaae\` — unblock CI tier-coherence + sweep dashboard-facing stale counts**

1. \`scripts/lib/tier-resolution.ts\` — add the four \`STATIC_PROFILE_KIND\` rows PR #35 left missing (\`china-hebei\`, \`china-heilongjiang\`, \`china-jilin\` as T3 wind; \`tva\` as T3 solar). Unblocks \`npm run ci:tier-coherence\`.
2. \`observablehq.config.ts\` — bump OG meta description + \`og:image:alt\` from \"128 regions\" to \"241 regions\". Affects every social-share unfurl.
3. \`src/about.md\` — same 128 → 241 sweep in the methodology deck on the /about page.

**\`3a499c1\` — sweep stale region counts in README + dataset/paper docs**

4. \`README.md\` — 128 → 241 in lede + citation; **DOI updated 19835566 (v1.0.0) → 19991315 (v1.1.1) + concept DOI added**; tier breakdown replaced with pointer to \`npm run tally:tiers\` (so it can't drift again); stale test count \"(205 across 82 files)\" dropped from the dev snippet.
5. \`dataset/README.md\` — 233 → 241 in the citation.
6. \`dataset/SCHEMA.md\` — 233 → 241 in the parquet size estimate.
7. \`docs/paper/01-background-and-summary.md\` + assembled DOCX source — a single missed table-cell in §3 that PR #36's sweep didn't catch.

## Test plan

- [x] \`npm run ci:tier-coherence\` — green (was hard-failing on \`main\`)
- [x] \`npm test\` — 402 passed
- [x] \`npm run typecheck\` — clean
- [x] No \`128|233|236 region\` refs left in any production-facing surface

## Skipped intentionally (historical refs that should stay)

\`dataset/CHANGELOG.md\` (version history); \`dataset/FAIR.md\` (tag-history prose); \`docs/paper/README.md\` (DOI history); \`docs/paper/05-usage-notes.md\` + \`06-code-availability.md\` (correctly reference v1.1.1, the current live version); \`docs/methodology/historical-backfill.md\` (references v1.0.0 as a historical data-archive milestone); \`docs/proposals/*.md\` (historical); \`docs/academic-model/*.md\` (internal planning notes); \`src/lib/types.ts\` (historical \"reserved in v1.0.0\" comment); \`STATUS.md\` (historical PR title).

## Out of scope — needs eyes-on, not a mechanical fix

\`npm run ci:tally-golden\` still drifts after this PR:

\`\`\`
T2: golden=2, actual=6 (Δ 4)
T2-flare: golden=8, actual=4 (Δ -4)
\`\`\`

Confirmed via \`npm run tally:tiers\`: \`qatar\`, \`kuwait\`, \`russia-yamal\`, \`russia-e-siberia\` are landing in T2 instead of T2-flare — even though their labels literally say \"(flare)\". The bucket-derivation logic isn't recognising them. Not a golden refresh — a real classification gap that needs deciding before paper resubmission. Out of scope here.