### PR TITLE
fix(dashboard): wire 9 PR #45 leftover regions in regionData

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -332,6 +332,23 @@ const regionData = {
   lithuania: entsoe.lithuania,
   latvia: entsoe.latvia,
   estonia: entsoe.estonia,
+  // PR #45 leftover Balkan + Baltic regions — wired per Phase 3a-v2 per-fuel split.
+  "bosnia-and-herzegovina": entsoe["bosnia-and-herzegovina"],
+  "croatia-wind": entsoe["croatia-wind"],
+  "croatia-solar": entsoe["croatia-solar"],
+  "luxembourg-wind": entsoe["luxembourg-wind"],
+  "luxembourg-solar": entsoe["luxembourg-solar"],
+  "moldova-wind": entsoe["moldova-wind"],
+  "moldova-solar": entsoe["moldova-solar"],
+  montenegro: entsoe.montenegro,
+  "north-macedonia-wind": entsoe["north-macedonia-wind"],
+  "north-macedonia-solar": entsoe["north-macedonia-solar"],
+  "serbia-wind": entsoe["serbia-wind"],
+  "serbia-solar": entsoe["serbia-solar"],
+  "slovakia-wind": entsoe["slovakia-wind"],
+  "slovakia-solar": entsoe["slovakia-solar"],
+  "slovenia-wind": entsoe["slovenia-wind"],
+  "slovenia-solar": entsoe["slovenia-solar"],
   // Switzerland — PV-only ENTSO-E feed; understates hydro spill but
   // captures summer-midday PV oversupply on Swissgrid's corridor.
   switzerland: entsoe.switzerland,


### PR DESCRIPTION
## Summary

Wires 9 Balkan/Baltic ENTSO-E regions declared in `regions.ts` (since PR #45, 2026-05-04) but never composed into `regionData` in `src/index.md`, so their globe pillars and hotspot rows rendered empty.

Regions wired (18 per-fuel keys total, matching Phase 3a-v2 loader emit list):
- bosnia-and-herzegovina (hydro)
- croatia, luxembourg, moldova, north-macedonia, serbia, slovakia, slovenia (wind+solar each)
- montenegro (hydro)

## Out of scope

Malta is also a PR #45 leftover but the ENTSO-E loader does not yet emit it (no zone/EIC entry in `src/data/entsoe.json.ts`). Separate loader-level fix.

## Test plan

- [x] vitest 416/416
- [x] tier-coherence
- [x] tally-golden (289, T1a=134 T1b=9)
- [x] docs-drift
- [x] validate (203/203 tier-enriched)
- [x] Local observable preview — globe renders, no console errors

The on-page region-count is derived from regions.ts not regionData, so the displayed number does not change. Fix is in what now renders on the globe and hotspot panel for these 9 regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)