### PR TITLE
feat(malta): add Enemalta ENTSO-E zone entry + wire in regionData

### DIFF
--- a/src/data/entsoe.json.ts
+++ b/src/data/entsoe.json.ts
@@ -324,6 +324,12 @@ export const ZONES = [
     technologies: [{ psrType: "B16", fuel: "solar", rate: 0.02 }],
     sourceNote: "Moldelectrica ENTSO-E A75 solar: regional default ~2%.",
   },
+  {
+    id: "malta",
+    domain: "10Y1001A1001A93C",
+    technologies: [{ psrType: "B16", fuel: "solar", rate: 0.02 }],
+    sourceNote: "Enemalta ENTSO-E A75 solar: regional default ~2% (PV-dominant island grid).",
+  },
 ] as const;
 
 export const parseEntsoeXml = parseEntsoeXmlImpl;

--- a/src/index.md
+++ b/src/index.md
@@ -340,6 +340,7 @@ const regionData = {
   "luxembourg-solar": entsoe["luxembourg-solar"],
   "moldova-wind": entsoe["moldova-wind"],
   "moldova-solar": entsoe["moldova-solar"],
+  malta: entsoe.malta,
   montenegro: entsoe.montenegro,
   "north-macedonia-wind": entsoe["north-macedonia-wind"],
   "north-macedonia-solar": entsoe["north-macedonia-solar"],


### PR DESCRIPTION
## Summary

Malta was declared in `regions.ts` (PR #45) but the ENTSO-E loader had no zone entry, so the dashboard rendered empty for Malta despite it being declared `live-tier solar`.

### Changes

1. **`src/data/entsoe.json.ts`** — Added Malta to the ZONES array:
   ```ts
   {
     id: "malta",
     domain: "10Y1001A1001A93C",
     technologies: [{ psrType: "B16", fuel: "solar", rate: 0.02 }],
     sourceNote: "Enemalta ENTSO-E A75 solar: regional default ~2% (PV-dominant island grid).",
   },
   ```

2. **`src/index.md`** — Wired `malta: entsoe.malta` alongside other PR #45 leftover regions.

### EIC Verification

⚠️ **The domain code `10Y1001A1001A93C` is based on the standard `10Y1001A1001A` prefix format used for other Mediterranean island TSOs (Sicily, Sardinia). It has not been independently verified against the ENTSO-E published EIC list.** If the cron-bot snapshot for Malta fails to populate, the EIC will need to be corrected against the [official ENTSO-E EIC list](https://www.entsoe.eu/data/energy-identification-codes-eic/).

## CI Gate Results

- [x] vitest 416/416 ✅
- [x] tier-coherence ✅
- [x] tally-golden ✅ (289 total — Malta already counted in regions.ts, no count change)
- [x] docs-drift ✅
- [x] validate ✅
- [x] tally:tiers ✅ (T1a=134 including Malta)

## Browser Preview

Awaiting Vercel preview deployment. Will verify:
- `document.getElementById('region-count').textContent` = "278"
- No console errors
- Globe renders with Malta pillar

---

Fixes: honeybeesquad/every-last-joule-dashboard#50