### PR TITLE
feat(globe): stacked composite pillars + stacked area chart popup

### DIFF
--- a/src/components/region-tooltip.js
+++ b/src/components/region-tooltip.js
@@ -4,13 +4,16 @@ import { getFuelColor, FUEL_LABEL, dominantFuel } from "../lib/fuel.js";
 /**
  * Floating detail card anchored to a globe click. Shows region identity,
  * live-updating "now" GW, 24h peak, 30d TWh, fuel, source link, and a
- * 24-hour sparkline. Live-subscribes to the clock so the "now" number
- * tweens as playback advances.
+ * 24-hour sparkline. For co-located multi-fuel groups (e.g. wind + solar
+ * at the same site) a stacked area chart is drawn instead.
  *
  * API:
  *   const tooltip = mountRegionTooltip({ clock, regionData, getMode, regions });
- *   tooltip.show(region, { clientX, clientY });
+ *   tooltip.show(regionOrGroup, { clientX, clientY });
  *   tooltip.hide();
+ *
+ * `regionOrGroup` is either a single Region object or an array of Regions
+ * sharing the same lat/lon (stacked composite pillar).
  */
 export function mountRegionTooltip({ clock, regionData, getMode, regions }) {
   const el = document.createElement("div");
@@ -20,7 +23,8 @@ export function mountRegionTooltip({ clock, regionData, getMode, regions }) {
   el.setAttribute("aria-label", "Region detail");
   document.body.appendChild(el);
 
-  let currentRegion = null;
+  // currentGroup is always an array (1+ regions).
+  let currentGroup = null;
   let clockSub = null;
 
   function fuelOf(region) {
@@ -36,6 +40,99 @@ export function mountRegionTooltip({ clock, regionData, getMode, regions }) {
   function fuelLabel(region) {
     if (region.kind === "flare") return "Flared gas";
     return FUEL_LABEL[dominantFuel(region, regionData[region.id])];
+  }
+
+  /**
+   * Draw a stacked area chart for a group of regions. Each member gets its
+   * own color band, stacked bottom-to-top in descending-average-GW order.
+   */
+  function drawStackedSparkline(canvas, group) {
+    if (!canvas) return;
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    const ctx = canvas.getContext("2d");
+    const w = rect.width;
+    const h = rect.height;
+    ctx.save();
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, w, h);
+    const pad = 2;
+    const plotW = w - pad * 2;
+    const plotH = h - pad * 2;
+
+    // Build per-hour stacked totals for each member.
+    const members = group.map((r) => ({
+      region: r,
+      profile: (regionData[r.id]?.profile ?? new Array(24).fill(0)),
+      color: colorFor(r),
+    }));
+
+    // Compute combined profile for y-axis scaling.
+    const combined = new Array(24).fill(0);
+    for (const m of members) {
+      for (let i = 0; i < 24; i++) combined[i] += (m.profile[i] ?? 0);
+    }
+    const maxG = Math.max(0.01, ...combined);
+
+    // Draw bands from bottom up (sorted largest-first so the biggest fuel
+    // is closest to the baseline — easier to compare).
+    const avgGW = (p) => p.reduce((s, v) => s + v, 0) / p.length;
+    const sorted = [...members].sort((a, b) => avgGW(b.profile) - avgGW(a.profile));
+
+    // Stack: accumulate baselines per hour.
+    const baseline = new Array(24).fill(0);
+    for (const m of sorted) {
+      const color = m.color;
+      // Fill band.
+      const fillGrad = ctx.createLinearGradient(0, pad, 0, h - pad);
+      fillGrad.addColorStop(0, color + "cc");
+      fillGrad.addColorStop(1, color + "44");
+      ctx.fillStyle = fillGrad;
+      ctx.beginPath();
+      // Bottom edge (current baseline)
+      for (let i = 0; i < 24; i++) {
+        const x = pad + (i / 23) * plotW;
+        const yBase = pad + plotH - (baseline[i] / maxG) * plotH;
+        if (i === 0) ctx.moveTo(x, yBase);
+        else ctx.lineTo(x, yBase);
+      }
+      // Top edge (baseline + this member)
+      for (let i = 23; i >= 0; i--) {
+        const x = pad + (i / 23) * plotW;
+        const yTop = pad + plotH - ((baseline[i] + (m.profile[i] ?? 0)) / maxG) * plotH;
+        ctx.lineTo(x, yTop);
+      }
+      ctx.closePath();
+      ctx.fill();
+      // Stroke along top edge.
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      for (let i = 0; i < 24; i++) {
+        const x = pad + (i / 23) * plotW;
+        const yTop = pad + plotH - ((baseline[i] + (m.profile[i] ?? 0)) / maxG) * plotH;
+        if (i === 0) ctx.moveTo(x, yTop);
+        else ctx.lineTo(x, yTop);
+      }
+      ctx.stroke();
+      // Advance baseline.
+      for (let i = 0; i < 24; i++) baseline[i] += (m.profile[i] ?? 0);
+    }
+
+    // Current-hour dot on top of the stack.
+    const hourNow = ((clock.hour % 24) + 24) % 24;
+    const cx = pad + (hourNow / 23) * plotW;
+    const interpIdx = Math.floor(hourNow) % 24;
+    const t = hourNow - Math.floor(hourNow);
+    const interpGW = (combined[interpIdx] ?? 0) * (1 - t) + (combined[(interpIdx + 1) % 24] ?? 0) * t;
+    const cy = pad + plotH - (interpGW / maxG) * plotH;
+    ctx.fillStyle = getFuelColor("flare");
+    ctx.beginPath();
+    ctx.arc(cx, cy, 2.5, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.restore();
   }
 
   function drawSparkline(canvas, data) {
@@ -56,7 +153,8 @@ export function mountRegionTooltip({ clock, regionData, getMode, regions }) {
     const pad = 2;
     const plotW = w - pad * 2;
     const plotH = h - pad * 2;
-    const color = currentRegion ? colorFor(currentRegion) : "#14afac";
+    const region = currentGroup?.[0];
+    const color = region ? colorFor(region) : "#14afac";
     // Fill
     const grad = ctx.createLinearGradient(0, pad, 0, h - pad);
     grad.addColorStop(0, color + "aa");
@@ -98,15 +196,28 @@ export function mountRegionTooltip({ clock, regionData, getMode, regions }) {
   }
 
   function updateLive() {
-    if (!currentRegion) return;
-    const data = regionData[currentRegion.id];
-    if (!data) return;
+    if (!currentGroup) return;
     const mode = getMode?.() ?? "avg30d";
-    const nowGW = regionGWAtHour(data, clock.hour, mode);
-    const nowEl = el.querySelector("[data-now]");
-    if (nowEl) nowEl.textContent = `${nowGW.toFixed(2)} GW`;
     const canvas = el.querySelector("canvas.region-tooltip-sparkline");
-    drawSparkline(canvas, data);
+
+    if (currentGroup.length > 1) {
+      // Multi-fuel group: sum GW across all members.
+      const nowGW = currentGroup.reduce((s, r) => {
+        const d = regionData[r.id];
+        return s + (d ? regionGWAtHour(d, clock.hour, mode) : 0);
+      }, 0);
+      const nowEl = el.querySelector("[data-now]");
+      if (nowEl) nowEl.textContent = `${nowGW.toFixed(2)} GW`;
+      drawStackedSparkline(canvas, currentGroup);
+    } else {
+      const region = currentGroup[0];
+      const data = regionData[region.id];
+      if (!data) return;
+      const nowGW = regionGWAtHour(data, clock.hour, mode);
+      const nowEl = el.querySelector("[data-now]");
+      if (nowEl) nowEl.textContent = `${nowGW.toFixed(2)} GW`;
+      drawSparkline(canvas, data);
+    }
   }
 
   function positionAnchor(anchor) {
@@ -156,52 +267,95 @@ export function mountRegionTooltip({ clock, regionData, getMode, regions }) {
     return `<span class="${klass}" title="sourceStatus=${status}; lastSuccessAt=${data.lastSuccessAt ?? "?"}; lastUpdated=${data.lastUpdated ?? "?"}">${icon} ${label}</span>`;
   }
 
-  function show(region, anchor) {
-    currentRegion = region;
-    const data = regionData[region.id];
+  function show(regionOrGroup, anchor) {
+    // Normalise to always-array.
+    currentGroup = Array.isArray(regionOrGroup) ? regionOrGroup : [regionOrGroup];
     const mode = getMode?.() ?? "avg30d";
-    const nowGW = data ? regionGWAtHour(data, clock.hour, mode) : 0;
-    const peakGW = data?.peakGW ?? 0;
-    const totalTWh = data?.totalTWh ?? 0;
-    const sourceNote = data?.sourceNote ?? "";
-    const color = colorFor(region);
-    const label = fuelLabel(region);
-    const fuel = fuelOf(region);
 
-    el.innerHTML = `
-      <button class="region-tooltip-close" aria-label="Close">&times;</button>
-      <div class="region-tooltip-header">
-        <span class="dot" style="background:${color};box-shadow:0 0 10px ${color}66;"></span>
-        <div class="region-tooltip-titles">
-          <span class="region-tooltip-name">${region.name}</span>
-          <span class="region-tooltip-country">${region.country} · ${label}</span>
+    if (currentGroup.length > 1) {
+      // Composite multi-fuel pillar: aggregate stats across all members.
+      const rep = currentGroup[0];
+      const nowGW = currentGroup.reduce((s, r) => {
+        const d = regionData[r.id];
+        return s + (d ? regionGWAtHour(d, clock.hour, mode) : 0);
+      }, 0);
+      const peakGW = currentGroup.reduce((s, r) => s + (regionData[r.id]?.peakGW ?? 0), 0);
+      const totalTWh = currentGroup.reduce((s, r) => s + (regionData[r.id]?.totalTWh ?? 0), 0);
+      // Build a legend row per fuel member.
+      const fuelRows = currentGroup
+        .map((r) => {
+          const c = colorFor(r);
+          const lbl = fuelLabel(r);
+          return `<span class="region-tooltip-fuel-swatch" style="background:${c};"></span>${lbl}`;
+        })
+        .join(" · ");
+      const anyData = currentGroup.find((r) => regionData[r.id]);
+      const badge = anyData ? freshnessBadge(regionData[anyData.id]) : "";
+
+      el.innerHTML = `
+        <button class="region-tooltip-close" aria-label="Close">&times;</button>
+        <div class="region-tooltip-header">
+          <div class="region-tooltip-titles">
+            <span class="region-tooltip-name">${rep.name.replace(/ (Wind|Solar|Hydro)$/, "")}</span>
+            <span class="region-tooltip-country">${rep.country} · ${fuelRows}</span>
+          </div>
         </div>
-      </div>
-      <div class="region-tooltip-stats">
-        <div class="region-tooltip-stat"><span>Now (UTC)</span><span class="num-tabular" data-now>${nowGW.toFixed(2)} GW</span></div>
-        <div class="region-tooltip-stat"><span>24h peak</span><span class="num-tabular">${peakGW.toFixed(2)} GW</span></div>
-        <div class="region-tooltip-stat"><span>30d total</span><span class="num-tabular">${totalTWh.toFixed(2)} TWh</span></div>
-      </div>
-      <canvas class="region-tooltip-sparkline" width="240" height="48" aria-label="24-hour curtailment profile"></canvas>
-      <div class="region-tooltip-footer">
-        ${region.sourceUrl ? `<a href="${region.sourceUrl}" target="_blank" rel="noopener noreferrer">${region.source}</a>` : `<span>${region.source ?? ""}</span>`}
-        ${freshnessBadge(data)}
-      </div>
-      ${sourceNote ? `<div class="region-tooltip-note" title="${sourceNote.replace(/"/g, "&quot;")}">${sourceNote.length > 110 ? sourceNote.slice(0, 108) + "…" : sourceNote}</div>` : ""}
-    `;
-    el.dataset.fuel = fuel;
+        <div class="region-tooltip-stats">
+          <div class="region-tooltip-stat"><span>Now (UTC)</span><span class="num-tabular" data-now>${nowGW.toFixed(2)} GW</span></div>
+          <div class="region-tooltip-stat"><span>24h peak</span><span class="num-tabular">${peakGW.toFixed(2)} GW</span></div>
+          <div class="region-tooltip-stat"><span>30d total</span><span class="num-tabular">${totalTWh.toFixed(2)} TWh</span></div>
+        </div>
+        <canvas class="region-tooltip-sparkline" width="240" height="48" aria-label="24-hour curtailment profile"></canvas>
+        <div class="region-tooltip-footer">
+          ${rep.sourceUrl ? `<a href="${rep.sourceUrl}" target="_blank" rel="noopener noreferrer">${rep.source}</a>` : `<span>${rep.source ?? ""}</span>`}
+          ${badge}
+        </div>
+      `;
+      el.dataset.fuel = fuelOf(rep);
+    } else {
+      const region = currentGroup[0];
+      const data = regionData[region.id];
+      const nowGW = data ? regionGWAtHour(data, clock.hour, mode) : 0;
+      const peakGW = data?.peakGW ?? 0;
+      const totalTWh = data?.totalTWh ?? 0;
+      const sourceNote = data?.sourceNote ?? "";
+      const color = colorFor(region);
+      const label = fuelLabel(region);
+      const fuel = fuelOf(region);
+
+      el.innerHTML = `
+        <button class="region-tooltip-close" aria-label="Close">&times;</button>
+        <div class="region-tooltip-header">
+          <span class="dot" style="background:${color};box-shadow:0 0 10px ${color}66;"></span>
+          <div class="region-tooltip-titles">
+            <span class="region-tooltip-name">${region.name}</span>
+            <span class="region-tooltip-country">${region.country} · ${label}</span>
+          </div>
+        </div>
+        <div class="region-tooltip-stats">
+          <div class="region-tooltip-stat"><span>Now (UTC)</span><span class="num-tabular" data-now>${nowGW.toFixed(2)} GW</span></div>
+          <div class="region-tooltip-stat"><span>24h peak</span><span class="num-tabular">${peakGW.toFixed(2)} GW</span></div>
+          <div class="region-tooltip-stat"><span>30d total</span><span class="num-tabular">${totalTWh.toFixed(2)} TWh</span></div>
+        </div>
+        <canvas class="region-tooltip-sparkline" width="240" height="48" aria-label="24-hour curtailment profile"></canvas>
+        <div class="region-tooltip-footer">
+          ${region.sourceUrl ? `<a href="${region.sourceUrl}" target="_blank" rel="noopener noreferrer">${region.source}</a>` : `<span>${region.source ?? ""}</span>`}
+          ${freshnessBadge(data)}
+        </div>
+        ${sourceNote ? `<div class="region-tooltip-note" title="${sourceNote.replace(/"/g, "&quot;")}">${sourceNote.length > 110 ? sourceNote.slice(0, 108) + "…" : sourceNote}</div>` : ""}
+      `;
+      el.dataset.fuel = fuel;
+    }
+
     el.hidden = false;
     positionAnchor(anchor);
-    // Wire close button
     el.querySelector(".region-tooltip-close")?.addEventListener("click", hide, { once: true });
-    // Draw sparkline after DOM paints to pick up correct canvas dimensions
     requestAnimationFrame(() => updateLive());
-    // Subscribe to clock if not already
     if (!clockSub) clockSub = clock.subscribe(() => updateLive());
   }
 
   function hide() {
-    currentRegion = null;
+    currentGroup = null;
     el.hidden = true;
     if (clockSub) { clockSub(); clockSub = null; }
   }

--- a/src/globe.js
+++ b/src/globe.js
@@ -82,8 +82,25 @@ export async function mountGlobe(canvas, initial) {
   window.addEventListener("themechange", refreshTokens);
 
   /**
-   * Hit-test: given client coords, return the closest rendered hotspot region
-   * within `threshold` pixels that sits on the near hemisphere, or null.
+   * Group regions by lat/lon so co-located wind+solar entries (e.g.
+   * caiso-wind + caiso-solar) render as a single stacked pillar.
+   * Returns an array of groups; each group is an array of regions sharing
+   * the same rounded lat/lon bucket.
+   */
+  function buildPillarGroups(regions) {
+    const map = new Map();
+    for (const region of regions) {
+      if (region.kind === "flare" && !state.showFlare) continue;
+      const key = `${region.lat.toFixed(4)},${region.lon.toFixed(4)}`;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key).push(region);
+    }
+    return Array.from(map.values());
+  }
+
+  /**
+   * Hit-test: given client coords, return the closest pillar group within
+   * `threshold` pixels on the near hemisphere, or null.
    */
   function hitTestRegion(clientX, clientY, threshold = 20) {
     const rect = canvas.getBoundingClientRect();
@@ -100,23 +117,26 @@ export async function mountGlobe(canvas, initial) {
     const px = clientX - rect.left;
     const py = clientY - rect.top;
 
-    let best = null;
+    const groups = buildPillarGroups(state.regions);
+    let bestGroup = null;
     let bestDist2 = threshold * threshold;
-    for (const region of state.regions) {
-      if (region.kind === "flare" && !state.showFlare) continue;
-      const dist = d3.geoDistance([region.lon, region.lat], centerLngLat);
-      if (dist > Math.PI / 2) continue; // far side of globe
-      const point = projection([region.lon, region.lat]);
+    for (const group of groups) {
+      const rep = group[0];
+      const dist = d3.geoDistance([rep.lon, rep.lat], centerLngLat);
+      if (dist > Math.PI / 2) continue;
+      const point = projection([rep.lon, rep.lat]);
       if (!point) continue;
       const dx = point[0] - px;
       const dy = point[1] - py;
       const d2 = dx * dx + dy * dy;
       if (d2 < bestDist2) {
         bestDist2 = d2;
-        best = region;
+        bestGroup = group;
       }
     }
-    return best;
+    // Return single region for groups of one; group array for stacked pillars.
+    if (!bestGroup) return null;
+    return bestGroup.length === 1 ? bestGroup[0] : bestGroup;
   }
 
   function resize() {
@@ -233,34 +253,40 @@ export async function mountGlobe(canvas, initial) {
     ctx.lineWidth = 0.8;
     ctx.stroke();
 
-    for (const region of state.regions) {
-      // Flare regions are renewable-dashboard-excluded: not scored in the
-      // headline, not bucketed in hotspot columns. They can be toggled
-      // visible via the flare button; hidden by default.
-      if (region.kind === "flare" && !state.showFlare) continue;
-      const data = state.regionData[region.id];
-      const gw = data ? regionGWAtHour(data, hour, state.mode) : 0;
-      if (gw <= 0.01) continue;
-      const dist = d3.geoDistance([region.lon, region.lat], center);
+    const pillarGroups = buildPillarGroups(state.regions);
+    for (const group of pillarGroups) {
+      const rep = group[0];
+      // Compute total GW across all members of this group.
+      const gwByRegion = group.map((r) => {
+        const data = state.regionData[r.id];
+        return data ? Math.max(0, regionGWAtHour(data, hour, state.mode)) : 0;
+      });
+      const totalGW = gwByRegion.reduce((s, g) => s + g, 0);
+      if (totalGW <= 0.01) continue;
+
+      const dist = d3.geoDistance([rep.lon, rep.lat], center);
       if (dist > Math.PI / 2) continue;
-      const point = projection([region.lon, region.lat]);
+      const point = projection([rep.lon, rep.lat]);
       if (!point) continue;
 
       const visible = 1 - dist / (Math.PI / 2);
-      const color = getFuelColor(region.kind === "flare" ? "flare" : dominantFuel(region, data));
-      const weight = Math.sqrt(gw);
+      const weight = Math.sqrt(totalGW);
       const glowR = 4 + weight * 5;
       const coreR = 1.5 + weight * 0.8;
       const centreX = width / 2;
       const centreY = height / 2;
-      const solarAngle = d3.geoDistance([region.lon, region.lat], [sunLng, sunLat]);
+      const solarAngle = d3.geoDistance([rep.lon, rep.lat], [sunLng, sunLat]);
       const sunlit = Math.max(0, Math.cos(solarAngle));
       const sunDim = 0.6 + 0.4 * Math.max(0, sunlit);
+
+      // Dominant color for glow + core dot.
+      const repData = state.regionData[rep.id];
+      const domColor = getFuelColor(rep.kind === "flare" ? "flare" : dominantFuel(rep, repData));
 
       ctx.save();
       ctx.filter = "blur(4px)";
       ctx.globalAlpha = 0.45 * visible;
-      ctx.fillStyle = color;
+      ctx.fillStyle = domColor;
       ctx.beginPath();
       ctx.arc(point[0], point[1], glowR, 0, Math.PI * 2);
       ctx.fill();
@@ -274,38 +300,78 @@ export async function mountGlobe(canvas, initial) {
         dy /= len;
         const pillarH = 3 + weight * 48;
         const pillarW = 3;
-        const tipX = point[0] + dx * pillarH;
-        const tipY = point[1] + dy * pillarH;
-        const pillarGradient = ctx.createLinearGradient(point[0], point[1], tipX, tipY);
-        // Base of pillar (at the hotspot) used to be 0x66 = 40% alpha, which
-        // made the lower half of every spike fade out — pillars read as too
-        // dim across all three themes. Bump to a theme-scoped --pillar-base-alpha
-        // (sunfire/eclipse 0x99 ≈ 60%, vellum 0xee ≈ 93%) so each theme tunes its
-        // own pillar boldness against its own day-side gradient. globalAlpha is
-        // pinned to 1.0 so tips render at full token brightness.
-        pillarGradient.addColorStop(0, `${color}${tokens.pillarBaseAlpha}`);
-        pillarGradient.addColorStop(1, color);
-        ctx.strokeStyle = pillarGradient;
-        ctx.lineWidth = pillarW;
-        ctx.lineCap = "round";
-        ctx.globalAlpha = 1.0 * visible * sunDim;
-        ctx.beginPath();
-        ctx.moveTo(point[0], point[1]);
-        ctx.lineTo(tipX, tipY);
-        ctx.stroke();
 
-        ctx.save();
-        ctx.filter = "blur(3px)";
-        ctx.globalAlpha = 0.5 * visible * sunDim;
-        ctx.fillStyle = color;
-        ctx.beginPath();
-        ctx.arc(tipX, tipY, pillarW * 1.6, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.restore();
+        if (group.length === 1) {
+          // Single-fuel pillar: same gradient style as before.
+          const tipX = point[0] + dx * pillarH;
+          const tipY = point[1] + dy * pillarH;
+          const pillarGradient = ctx.createLinearGradient(point[0], point[1], tipX, tipY);
+          pillarGradient.addColorStop(0, `${domColor}${tokens.pillarBaseAlpha}`);
+          pillarGradient.addColorStop(1, domColor);
+          ctx.strokeStyle = pillarGradient;
+          ctx.lineWidth = pillarW;
+          ctx.lineCap = "round";
+          ctx.globalAlpha = visible * sunDim;
+          ctx.beginPath();
+          ctx.moveTo(point[0], point[1]);
+          ctx.lineTo(tipX, tipY);
+          ctx.stroke();
+
+          ctx.save();
+          ctx.filter = "blur(3px)";
+          ctx.globalAlpha = 0.5 * visible * sunDim;
+          ctx.fillStyle = domColor;
+          ctx.beginPath();
+          ctx.arc(tipX, tipY, pillarW * 1.6, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.restore();
+        } else {
+          // Stacked composite pillar: draw one segment per member, proportional to GW.
+          // Sort by GW descending so the largest fuel is at the base.
+          const segments = group
+            .map((r, i) => ({ region: r, gw: gwByRegion[i] }))
+            .filter((s) => s.gw > 0)
+            .sort((a, b) => b.gw - a.gw);
+          let segStart = 0;
+          for (const seg of segments) {
+            const segFrac = seg.gw / totalGW;
+            const segLen = pillarH * segFrac;
+            const segStartX = point[0] + dx * segStart;
+            const segStartY = point[1] + dy * segStart;
+            const segEndX = segStartX + dx * segLen;
+            const segEndY = segStartY + dy * segLen;
+            const segData = state.regionData[seg.region.id];
+            const segColor = getFuelColor(seg.region.kind === "flare" ? "flare" : dominantFuel(seg.region, segData));
+            const isBase = segStart === 0;
+            const isTip = segStart + segLen >= pillarH - 0.5;
+            const grad = ctx.createLinearGradient(segStartX, segStartY, segEndX, segEndY);
+            grad.addColorStop(0, isBase ? `${segColor}${tokens.pillarBaseAlpha}` : segColor);
+            grad.addColorStop(1, segColor);
+            ctx.strokeStyle = grad;
+            ctx.lineWidth = pillarW;
+            ctx.lineCap = isTip ? "round" : "butt";
+            ctx.globalAlpha = visible * sunDim;
+            ctx.beginPath();
+            ctx.moveTo(segStartX, segStartY);
+            ctx.lineTo(segEndX, segEndY);
+            ctx.stroke();
+            if (isTip) {
+              ctx.save();
+              ctx.filter = "blur(3px)";
+              ctx.globalAlpha = 0.5 * visible * sunDim;
+              ctx.fillStyle = segColor;
+              ctx.beginPath();
+              ctx.arc(segEndX, segEndY, pillarW * 1.6, 0, Math.PI * 2);
+              ctx.fill();
+              ctx.restore();
+            }
+            segStart += segLen;
+          }
+        }
       }
 
       ctx.globalAlpha = visible;
-      ctx.fillStyle = color;
+      ctx.fillStyle = domColor;
       ctx.beginPath();
       ctx.arc(point[0], point[1], coreR, 0, Math.PI * 2);
       ctx.fill();

--- a/src/style.css
+++ b/src/style.css
@@ -1017,6 +1017,15 @@ main table {
   color: rgba(255, 255, 255, 0.4);
 }
 
+.region-tooltip-fuel-swatch {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  vertical-align: middle;
+  margin-right: 2px;
+}
+
 .stat {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

- Co-located wind+solar regions (e.g. CAISO, MISO, PJM, SPP, BPA, NYISO-rest, ISO-NE-rest, ERCOT-east/west) now render as a single **stacked composite pillar** with color-coded fuel segments proportional to each fuel's GW output, rather than two overlapping identical-height pillars
- Clicking a stacked pillar opens a **composite popup** showing summed Now/Peak/30d stats and a **stacked area sparkline** with per-fuel bands (wind in cyan, solar in yellow)
- Single-fuel regions are unchanged — same gradient pillar + single-color sparkline as before

## Changes

- **`src/globe.js`**: `buildPillarGroups()` groups regions by lat/lon; rendering loop draws one stacked pillar per group; hit-test returns group array for co-located regions or single region for isolated ones
- **`src/components/region-tooltip.js`**: `show()` accepts either a single region or an array; `drawStackedSparkline()` renders per-fuel stacked area chart; composite header shows fuel swatch dots + stripped fuel suffix from name
- **`src/style.css`**: `.region-tooltip-fuel-swatch` for inline 7px colored dots

## Test plan

- [ ] All 413 tests pass (`npm test`)
- [ ] CI gates pass (`npm run ci:gates`)
- [ ] Globe loads and renders stacked pillars for US ISO regions (CAISO, ERCOT-east, ERCOT-west, MISO, PJM, SPP, BPA, NYISO-rest, ISO-NE-rest)
- [ ] Clicking a stacked pillar shows composite popup with fuel swatches + stacked area sparkline
- [ ] Clicking a single-fuel region (e.g. a European wind zone) shows single-color popup unchanged
- [ ] Theme switching (sunfire/eclipse/vellum) re-paints sparklines correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)