### PR TITLE
feat(malta): re-land Enemalta ENTSO-E A75 solar region

### DIFF
--- a/src/data/entsoe.json.ts
+++ b/src/data/entsoe.json.ts
@@ -324,6 +324,12 @@ export const ZONES = [
     technologies: [{ psrType: "B16", fuel: "solar", rate: 0.02 }],
     sourceNote: "Moldelectrica ENTSO-E A75 solar: regional default ~2%.",
   },
+  {
+    id: "malta",
+    domain: "10Y1001A1001A93C",
+    technologies: [{ psrType: "B16", fuel: "solar", rate: 0.02 }],
+    sourceNote: "Enemalta ENTSO-E A75 solar: regional default ~2% (PV-dominant island grid).",
+  },
 ] as const;
 
 export const parseEntsoeXml = parseEntsoeXmlImpl;

--- a/src/index.md
+++ b/src/index.md
@@ -361,6 +361,7 @@ const regionData = {
   "luxembourg-solar": entsoe["luxembourg-solar"],
   "moldova-wind": entsoe["moldova-wind"],
   "moldova-solar": entsoe["moldova-solar"],
+  malta: entsoe.malta,
   montenegro: entsoe.montenegro,
   "north-macedonia-wind": entsoe["north-macedonia-wind"],
   "north-macedonia-solar": entsoe["north-macedonia-solar"],


### PR DESCRIPTION
## Summary

- Re-adds Malta (`10Y1001A1001A93C` / Enemalta) to the ENTSO-E ZONES array in `src/data/entsoe.json.ts`
- Wires `malta: entsoe.malta` in `src/index.md`
- EIC confirmed correct via ENTSO-E approved codes registry and entsoe-py reference implementation
- Snapshot will be fetched live by Vercel at build time (no stale snapshot to migrate)

## Why reverted previously

PR #50 added Malta with a "verify EIC if snapshot fails" caveat. The EIC was never formally verified before the revert. It's now confirmed: `MT = '10Y1001A1001A93C'` (Malta BZ / CA / MBA).

## Test plan

- [x] 413/413 vitest pass
- [x] tier-coherence clean
- [x] tally-golden matches (318 regions)
- [x] docs-drift clean
- [x] validate clean
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)