### PR TITLE
feat(globe): split co-located wind/solar pillars 44px apart (WCAG 2.5.5)

### DIFF
--- a/src/data/ireland.json.ts
+++ b/src/data/ireland.json.ts
@@ -151,7 +151,11 @@ function trailingPoints(points: CurtailmentPoint[], days = 30): CurtailmentPoint
 }
 
 function buildRegion(
-  regionId: "ireland-republic" | "northern-ireland",
+  regionId:
+    | "ireland-republic-wind"
+    | "ireland-republic-solar"
+    | "northern-ireland-wind"
+    | "northern-ireland-solar",
   allIslandPoints: CurtailmentPoint[],
   share: number,
   lastUpdated: string,

--- a/src/globe.js
+++ b/src/globe.js
@@ -3,6 +3,7 @@ import * as topojson from "npm:topojson-client";
 import { regionGWAtHour } from "./lib/calc.js";
 import { getFuelColor, dominantFuel } from "./lib/fuel.js";
 import { readGlobeTokens, isLinearGradientToken } from "./lib/theme-tokens.js";
+import { buildPillarUnits } from "./lib/pillar-layout.js";
 
 /**
  * Open-Meteo free weather API: https://api.open-meteo.com/v1/forecast
@@ -220,21 +221,14 @@ export async function mountGlobe(canvas, initial) {
 
   window.addEventListener("themechange", refreshTokens);
 
-  /**
-   * Group regions by lat/lon so co-located wind+solar entries (e.g.
-   * caiso-wind + caiso-solar) render as a single stacked pillar.
-   * Returns an array of groups; each group is an array of regions sharing
-   * the same rounded lat/lon bucket.
-   */
-  function buildPillarGroups(regions) {
-    const map = new Map();
-    for (const region of regions) {
-      if (region.kind === "flare" && !state.showFlare) continue;
-      const key = `${region.lat.toFixed(4)},${region.lon.toFixed(4)}`;
-      if (!map.has(key)) map.set(key, []);
-      map.get(key).push(region);
-    }
-    return Array.from(map.values());
+  // Bucket co-located regions, then split multi-kind buckets into adjacent
+  // screen-x pillars 44px apart so each fuel is individually tappable
+  // (WCAG 2.5.5). Same-kind multi-region buckets stay stacked at offset 0.
+  function buildPillarUnitsForState() {
+    const filtered = state.regions.filter(
+      (region) => !(region.kind === "flare" && !state.showFlare),
+    );
+    return buildPillarUnits(filtered);
   }
 
   /**
@@ -256,26 +250,27 @@ export async function mountGlobe(canvas, initial) {
     const px = clientX - rect.left;
     const py = clientY - rect.top;
 
-    const groups = buildPillarGroups(state.regions);
-    let bestGroup = null;
+    const units = buildPillarUnitsForState();
+    let bestUnit = null;
     let bestDist2 = threshold * threshold;
-    for (const group of groups) {
-      const rep = group[0];
+    for (const unit of units) {
+      const rep = unit.regions[0];
       const dist = d3.geoDistance([rep.lon, rep.lat], centerLngLat);
       if (dist > Math.PI / 2) continue;
       const point = projection([rep.lon, rep.lat]);
       if (!point) continue;
-      const dx = point[0] - px;
+      const targetX = point[0] + unit.offsetPx;
+      const dx = targetX - px;
       const dy = point[1] - py;
       const d2 = dx * dx + dy * dy;
       if (d2 < bestDist2) {
         bestDist2 = d2;
-        bestGroup = group;
+        bestUnit = unit;
       }
     }
-    // Return single region for groups of one; group array for stacked pillars.
-    if (!bestGroup) return null;
-    return bestGroup.length === 1 ? bestGroup[0] : bestGroup;
+    // Return single region for units of one; region array for stacked pillars.
+    if (!bestUnit) return null;
+    return bestUnit.regions.length === 1 ? bestUnit.regions[0] : bestUnit.regions;
   }
 
   function resize() {
@@ -392,10 +387,11 @@ export async function mountGlobe(canvas, initial) {
     ctx.lineWidth = 0.8;
     ctx.stroke();
 
-    const pillarGroups = buildPillarGroups(state.regions);
-    for (const group of pillarGroups) {
+    const pillarUnits = buildPillarUnitsForState();
+    for (const unit of pillarUnits) {
+      const group = unit.regions;
       const rep = group[0];
-      // Compute total GW across all members of this group.
+      // Compute total GW across all members of this unit.
       const gwByRegion = group.map((r) => {
         const data = state.regionData[r.id];
         return data ? Math.max(0, regionGWAtHour(data, hour, state.mode)) : 0;
@@ -407,6 +403,12 @@ export async function mountGlobe(canvas, initial) {
       if (dist > Math.PI / 2) continue;
       const point = projection([rep.lon, rep.lat]);
       if (!point) continue;
+
+      // Anchor for this unit: original projection point shifted horizontally
+      // on screen by offsetPx so co-located wind/solar pairs render as
+      // adjacent tappable pillars 44px apart (WCAG 2.5.5).
+      const anchorX = point[0] + unit.offsetPx;
+      const anchorY = point[1];
 
       const visible = 1 - dist / (Math.PI / 2);
       const weight = Math.sqrt(totalGW);
@@ -427,10 +429,13 @@ export async function mountGlobe(canvas, initial) {
       ctx.globalAlpha = 0.45 * visible;
       ctx.fillStyle = domColor;
       ctx.beginPath();
-      ctx.arc(point[0], point[1], glowR, 0, Math.PI * 2);
+      ctx.arc(anchorX, anchorY, glowR, 0, Math.PI * 2);
       ctx.fill();
       ctx.restore();
 
+      // Outward direction from globe centre is anchored at the original
+      // projection point so all offset pillars within a bucket lean the
+      // same way (parallel bars 44px apart on screen).
       let dx = point[0] - centreX;
       let dy = point[1] - centreY;
       const len = Math.sqrt(dx * dx + dy * dy);
@@ -442,9 +447,9 @@ export async function mountGlobe(canvas, initial) {
 
         if (group.length === 1) {
           // Single-fuel pillar: same gradient style as before.
-          const tipX = point[0] + dx * pillarH;
-          const tipY = point[1] + dy * pillarH;
-          const pillarGradient = ctx.createLinearGradient(point[0], point[1], tipX, tipY);
+          const tipX = anchorX + dx * pillarH;
+          const tipY = anchorY + dy * pillarH;
+          const pillarGradient = ctx.createLinearGradient(anchorX, anchorY, tipX, tipY);
           pillarGradient.addColorStop(0, `${domColor}${tokens.pillarBaseAlpha}`);
           pillarGradient.addColorStop(1, domColor);
           ctx.strokeStyle = pillarGradient;
@@ -452,7 +457,7 @@ export async function mountGlobe(canvas, initial) {
           ctx.lineCap = "round";
           ctx.globalAlpha = visible * sunDim;
           ctx.beginPath();
-          ctx.moveTo(point[0], point[1]);
+          ctx.moveTo(anchorX, anchorY);
           ctx.lineTo(tipX, tipY);
           ctx.stroke();
 
@@ -475,8 +480,8 @@ export async function mountGlobe(canvas, initial) {
           for (const seg of segments) {
             const segFrac = seg.gw / totalGW;
             const segLen = pillarH * segFrac;
-            const segStartX = point[0] + dx * segStart;
-            const segStartY = point[1] + dy * segStart;
+            const segStartX = anchorX + dx * segStart;
+            const segStartY = anchorY + dy * segStart;
             const segEndX = segStartX + dx * segLen;
             const segEndY = segStartY + dy * segLen;
             const segData = state.regionData[seg.region.id];
@@ -512,7 +517,7 @@ export async function mountGlobe(canvas, initial) {
       ctx.globalAlpha = visible;
       ctx.fillStyle = domColor;
       ctx.beginPath();
-      ctx.arc(point[0], point[1], coreR, 0, Math.PI * 2);
+      ctx.arc(anchorX, anchorY, coreR, 0, Math.PI * 2);
       ctx.fill();
       ctx.strokeStyle = "rgba(255, 255, 255, 0.85)";
       ctx.lineWidth = 0.6;
@@ -525,7 +530,7 @@ export async function mountGlobe(canvas, initial) {
         ctx.lineWidth = 2.2;
         ctx.setLineDash([]);
         ctx.beginPath();
-        ctx.arc(point[0], point[1], glowR + 5, 0, Math.PI * 2);
+        ctx.arc(anchorX, anchorY, glowR + 5, 0, Math.PI * 2);
         ctx.stroke();
         ctx.restore();
       }

--- a/src/lib/pillar-layout.ts
+++ b/src/lib/pillar-layout.ts
@@ -1,0 +1,62 @@
+// Co-located wind/solar regions get split into adjacent screen-x pillars
+// 44px centre-to-centre apart so each is individually tappable per WCAG 2.5.5
+// (minimum 44x44 touch target). Single-kind buckets are unchanged.
+
+export const PILLAR_SEPARATION_PX = 44;
+
+const KIND_ORDER: Record<string, number> = {
+  wind: 0,
+  solar: 1,
+  hydro: 2,
+  geo: 3,
+  mixed: 4,
+  flare: 5,
+};
+
+export interface PillarRegion {
+  id: string;
+  lat: number;
+  lon: number;
+  kind: string;
+}
+
+export interface PillarUnit<R extends PillarRegion = PillarRegion> {
+  regions: R[];
+  offsetPx: number;
+}
+
+function compareRegion(a: PillarRegion, b: PillarRegion): number {
+  const ka = KIND_ORDER[a.kind] ?? 99;
+  const kb = KIND_ORDER[b.kind] ?? 99;
+  if (ka !== kb) return ka - kb;
+  return a.id.localeCompare(b.id);
+}
+
+export function buildPillarUnits<R extends PillarRegion>(regions: R[]): PillarUnit<R>[] {
+  const buckets = new Map<string, R[]>();
+  for (const region of regions) {
+    const key = `${region.lat.toFixed(4)},${region.lon.toFixed(4)}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(key, bucket);
+    }
+    bucket.push(region);
+  }
+
+  const units: PillarUnit<R>[] = [];
+  for (const bucket of buckets.values()) {
+    const distinctKinds = new Set(bucket.map((r) => r.kind));
+    if (distinctKinds.size <= 1) {
+      units.push({ regions: [...bucket].sort(compareRegion), offsetPx: 0 });
+      continue;
+    }
+    const sorted = [...bucket].sort(compareRegion);
+    const n = sorted.length;
+    sorted.forEach((region, i) => {
+      const offsetPx = (i - (n - 1) / 2) * PILLAR_SEPARATION_PX;
+      units.push({ regions: [region], offsetPx });
+    });
+  }
+  return units;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,7 +25,7 @@ export type RegionTier =
   | "flare";
 
 /** The waste modality drives colouring (teal vs orange) and narrative. */
-export type RegionKind = "solar" | "wind" | "hydro" | "mixed" | "flare";
+export type RegionKind = "solar" | "wind" | "hydro" | "geo" | "mixed" | "flare";
 
 /** Freshness state of an upstream source or fallback snapshot. */
 export type SourceStatus = "live" | "cached" | "degraded";

--- a/tests/pillar-layout.test.ts
+++ b/tests/pillar-layout.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import { buildPillarUnits, PILLAR_SEPARATION_PX } from "../src/lib/pillar-layout";
+
+const r = (id: string, lat: number, lon: number, kind: string) => ({ id, lat, lon, kind });
+
+describe("buildPillarUnits", () => {
+  test("single-kind bucket renders as one unit at offset 0", () => {
+    const units = buildPillarUnits([r("germany-wind", 51.0, 10.0, "wind")]);
+    expect(units).toHaveLength(1);
+    expect(units[0].offsetPx).toBe(0);
+    expect(units[0].regions.map((x) => x.id)).toEqual(["germany-wind"]);
+  });
+
+  test("co-located wind+solar split into two units >=40px apart", () => {
+    const units = buildPillarUnits([
+      r("spain-solar", 40.4168, -3.7038, "solar"),
+      r("spain-wind", 40.4168, -3.7038, "wind"),
+    ]);
+    expect(units).toHaveLength(2);
+    const wind = units.find((u) => u.regions[0].id === "spain-wind")!;
+    const solar = units.find((u) => u.regions[0].id === "spain-solar")!;
+    expect(Math.abs(solar.offsetPx - wind.offsetPx)).toBeGreaterThanOrEqual(40);
+    expect(Math.abs(solar.offsetPx - wind.offsetPx)).toBe(PILLAR_SEPARATION_PX);
+  });
+
+  test("wind sorts left of solar in any pair (deterministic)", () => {
+    const units = buildPillarUnits([
+      r("spain-solar", 40.4168, -3.7038, "solar"),
+      r("spain-wind", 40.4168, -3.7038, "wind"),
+    ]);
+    const wind = units.find((u) => u.regions[0].id === "spain-wind")!;
+    const solar = units.find((u) => u.regions[0].id === "spain-solar")!;
+    expect(wind.offsetPx).toBeLessThan(solar.offsetPx);
+  });
+
+  test("three-kind bucket spreads at 44px increments centred on 0", () => {
+    const units = buildPillarUnits([
+      r("x-hydro", 0, 0, "hydro"),
+      r("x-solar", 0, 0, "solar"),
+      r("x-wind", 0, 0, "wind"),
+    ]);
+    expect(units).toHaveLength(3);
+    const offsets = units.map((u) => u.offsetPx).sort((a, b) => a - b);
+    expect(offsets).toEqual([-PILLAR_SEPARATION_PX, 0, PILLAR_SEPARATION_PX]);
+  });
+
+  test("distinct lat/lon keep their own bucket (no false merge)", () => {
+    const units = buildPillarUnits([
+      r("brazil-bahia-wind", -12.9, -41.0, "wind"),
+      r("brazil-bahia-solar", -12.95, -41.05, "solar"),
+    ]);
+    expect(units).toHaveLength(2);
+    expect(units.every((u) => u.offsetPx === 0)).toBe(true);
+  });
+
+  test("same-kind regions at same coord stack into one unit (no offset)", () => {
+    const units = buildPillarUnits([
+      r("a-wind", 10, 20, "wind"),
+      r("b-wind", 10, 20, "wind"),
+    ]);
+    expect(units).toHaveLength(1);
+    expect(units[0].offsetPx).toBe(0);
+    expect(units[0].regions).toHaveLength(2);
+  });
+
+  test("flare colocated with renewables splits like other kinds", () => {
+    const units = buildPillarUnits([
+      r("iraq-flare", 33, 44, "flare"),
+      r("iraq-solar", 33, 44, "solar"),
+    ]);
+    expect(units).toHaveLength(2);
+    const flare = units.find((u) => u.regions[0].id === "iraq-flare")!;
+    const solar = units.find((u) => u.regions[0].id === "iraq-solar")!;
+    expect(Math.abs(flare.offsetPx - solar.offsetPx)).toBe(PILLAR_SEPARATION_PX);
+    // solar before flare in deterministic order
+    expect(solar.offsetPx).toBeLessThan(flare.offsetPx);
+  });
+});


### PR DESCRIPTION
## Summary

Completes Part B of the per-fuel globalisation brief that PR #60 missed — refactors the globe pillar grouping so co-located wind/solar pairs render as **adjacent tappable pillars 44px apart on screen** instead of a single stacked composite.

Previously \`buildPillarGroups\` bucketed regions by \`lat.toFixed(4),lon.toFixed(4)\` and rendered each bucket as one composite bar with stacked colour segments. That's why \`spain-wind\` + \`spain-solar\` (both at Madrid's centroid post-PR #60) showed as one bar, while \`brazil-bahia-wind\` + \`brazil-bahia-solar\` showed as two — Bahia's centroids happen to differ; Spain's don't.

## What changed

**New pure module:** \`src/lib/pillar-layout.ts\`
- \`buildPillarUnits(regions)\` returns \`{regions, offsetPx}[]\`
- For multi-kind buckets: split into N adjacent units, \`offsetPx = (i - (n-1)/2) * 44\`
- Single-kind buckets unchanged (offset 0, regions stack as before)
- Deterministic ordering: kind (wind, solar, hydro, geo, mixed, flare), ties by id → wind always left of solar in any pair
- \`PILLAR_SEPARATION_PX = 44\` documented inline (WCAG 2.5.5 minimum touch target)

**\`src/globe.js\` (render + hit-test):**
- Render loop anchors each pillar at \`point[0] + unit.offsetPx\` (\`anchorX/anchorY\`); outward direction \`dx,dy\` still computed from original projection point so all offset pillars in a bucket lean parallel
- Selection ring follows the offset
- \`hitTestRegion\` mirrors the same offset, so click targets match what's drawn

## Tests

7 new unit tests in \`tests/pillar-layout.test.ts\`:
- Single-kind bucket → one unit at offset 0
- Co-located wind+solar → two units, separation = 44px
- Wind sorts left of solar (deterministic)
- Three-kind bucket spreads at \`-44, 0, +44\`
- Distinct lat/lon stays unbucketed
- Same-kind same-coord regions still stack into one unit
- Flare colocated with renewables splits like other kinds

## Gate sweep (local, all green)

| Gate | Result |
|---|---|
| vitest | 456 tests pass (449 prior + 7 new) |
| tier-coherence | 221 records / 109 files |
| tally-golden | 383 = 155 / 9 / 1 / 6 / 8 / 204 |
| docs-drift | 383 regions aligned |
| validate | 221/221 conform |
| build | 4 pages, dist emitted |

## Test plan

- [ ] Vercel preview deploy renders Spain as two adjacent pillars (wind left, solar right), 44px apart
- [ ] Bahia continues to render as two pillars (was already separate via distinct centroids — confirms no regression)
- [ ] Clicking spain-wind pillar opens \`spain-wind\` panel; clicking spain-solar opens \`spain-solar\` panel (separate hit targets)
- [ ] Selection ring centres on the clicked offset pillar, not the original centroid
- [ ] Single-fuel countries (UK, Germany, etc.) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)