### PR TITLE
fix(nz): three NZ pillars (wind/solar/geo) now render with distinct colors

### DIFF
--- a/src/data/new-zealand.json.ts
+++ b/src/data/new-zealand.json.ts
@@ -118,6 +118,12 @@ export function buildNewZealandPerFuelData(parsed: NzParsed): { wind: RegionData
   const solarPts = makePerFuelPoints(solarFrac);
   const geoPts = makePerFuelPoints(geoFrac);
 
+  // Per-fuel regions deliberately do NOT carry the country-level fuelShare:
+  // each region's totalTWh is already the per-fuel slice, and attaching the
+  // shared mix would make dominantFuel(region) collapse all three regions
+  // to whichever fuel happens to dominate the country mix (geothermal here)
+  // — the Mar 2026 "all three NZ pillars same colour" bug. The mix info
+  // remains visible in sourceNote.
   return {
     wind: {
       regionId: "new-zealand-wind",
@@ -128,7 +134,6 @@ export function buildNewZealandPerFuelData(parsed: NzParsed): { wind: RegionData
       lastUpdated,
       lastSuccessAt: lastUpdated,
       sourceNote: noteBase + " — wind share",
-      ...(fuelShare ? { fuelShare } : {}),
     },
     solar: {
       regionId: "new-zealand-solar",
@@ -139,7 +144,6 @@ export function buildNewZealandPerFuelData(parsed: NzParsed): { wind: RegionData
       lastUpdated,
       lastSuccessAt: lastUpdated,
       sourceNote: noteBase + " — solar share",
-      ...(fuelShare ? { fuelShare } : {}),
     },
     geo: {
       regionId: "new-zealand-geo",
@@ -150,7 +154,6 @@ export function buildNewZealandPerFuelData(parsed: NzParsed): { wind: RegionData
       lastUpdated,
       lastSuccessAt: lastUpdated,
       sourceNote: noteBase + " — geothermal share",
-      ...(fuelShare ? { fuelShare } : {}),
     },
   };
 }

--- a/src/lib/fuel.ts
+++ b/src/lib/fuel.ts
@@ -89,6 +89,9 @@ export function fuelShare(region: Region, fuel: Fuel, regionData?: RegionData): 
   if (region.kind === "solar" && fuel === "solar") return 1;
   if (region.kind === "wind"  && fuel === "wind")  return 1;
   if (region.kind === "hydro" && fuel === "hydro") return 1;
+  // Geothermal collapses into the hydro bucket for the 3-way fuel scheme:
+  // both are always-on baseload renewables, narratively grouped together.
+  if (region.kind === "geo"   && fuel === "hydro") return 1;
   return 0;
 }
 
@@ -123,5 +126,6 @@ export function dominantFuel(region: Region, regionData?: RegionData): Fuel {
   }
   if (region.kind === "wind")  return "wind";
   if (region.kind === "hydro") return "hydro";
+  if (region.kind === "geo")   return "hydro"; // geo collapses to hydro bucket
   return "solar"; // solar + any unclassified renewable default
 }

--- a/tests/fuel-attribution.test.ts
+++ b/tests/fuel-attribution.test.ts
@@ -1,0 +1,63 @@
+// Regression cover for the "all three NZ pillars same colour" bug
+// (Mar 2026): the loader was attaching the country-level fuelShare to all
+// three per-fuel NZ regions, and dominantFuel ranks fuelShare ahead of
+// region.kind, so wind/solar/geo all collapsed to whichever fuel
+// dominated the country mix (geothermal). Two protections:
+// 1. NZ loader no longer attaches country-level fuelShare to per-fuel regions.
+// 2. dominantFuel + fuelShare map kind="geo" to the hydro bucket so a
+//    geo region without fuelShare still gets a distinct colour from solar.
+
+import { describe, expect, test } from "vitest";
+import { dominantFuel, fuelShare } from "../src/lib/fuel";
+import type { Region, RegionData } from "../src/lib/types";
+
+const r = (id: string, kind: Region["kind"]): Region => ({
+  id,
+  name: id,
+  country: "NZL",
+  lat: 0,
+  lon: 0,
+  tier: "live",
+  kind,
+  source: "",
+  sourceUrl: "",
+});
+
+describe("dominantFuel — canonical kinds", () => {
+  test("kind=wind → wind", () => {
+    expect(dominantFuel(r("nz-wind", "wind"))).toBe("wind");
+  });
+  test("kind=solar → solar", () => {
+    expect(dominantFuel(r("nz-solar", "solar"))).toBe("solar");
+  });
+  test("kind=hydro → hydro", () => {
+    expect(dominantFuel(r("nz-hydro", "hydro"))).toBe("hydro");
+  });
+  test("kind=geo → hydro (geo folds into the hydro bucket)", () => {
+    expect(dominantFuel(r("nz-geo", "geo"))).toBe("hydro");
+  });
+});
+
+describe("fuelShare — canonical kinds attribute 100% to their bucket", () => {
+  test("kind=wind contributes 1 to wind, 0 to others", () => {
+    const reg = r("x-wind", "wind");
+    expect(fuelShare(reg, "wind")).toBe(1);
+    expect(fuelShare(reg, "solar")).toBe(0);
+    expect(fuelShare(reg, "hydro")).toBe(0);
+  });
+  test("kind=geo contributes 1 to hydro bucket, 0 to others", () => {
+    const reg = r("nz-geo", "geo");
+    expect(fuelShare(reg, "wind")).toBe(0);
+    expect(fuelShare(reg, "solar")).toBe(0);
+    expect(fuelShare(reg, "hydro")).toBe(1);
+  });
+});
+
+describe("dominantFuel — kind=mixed uses fuelShare", () => {
+  test("kind=mixed with fuelShare returns the dominant share", () => {
+    const data: Partial<RegionData> = {
+      fuelShare: { wind: 0.3, solar: 0.6, hydro: 0.1 },
+    };
+    expect(dominantFuel(r("blended", "mixed"), data as RegionData)).toBe("solar");
+  });
+});


### PR DESCRIPTION
## Bug

\`new-zealand-wind\`, \`new-zealand-solar\`, and \`new-zealand-geo\` all rendered with the same colour on the globe.

## Root cause

The NZ loader attached the **country-level** \`fuelShare\` (e.g., \`{wind: 0.18, solar: 0.05, hydro: 0.77}\` where hydro = geothermal) to all three per-fuel regions. \`dominantFuel\` ranks \`fuelShare\` ahead of \`region.kind\`, so all three regions resolved to whichever fuel dominated the country mix — collapsing three distinct kinds to one colour.

This was specific to NZ because it's the only 3-way per-fuel split with a fuelShare hydro key. Other ISO regions (MISO, SPP, etc.) carry a \`{wind, solar}\` fuelShare which still lets each fuel win in its own region (wind > solar in wind region, etc.) — so the bug doesn't visibly manifest there.

## Fix

**Two parts:**

1. **\`src/data/new-zealand.json.ts\`** — per-fuel regions no longer carry the country-level \`fuelShare\`. Each region's \`totalTWh\` is already the per-fuel slice; attaching the shared mix was incorrect at this granularity. The mix info is preserved in \`sourceNote\`.

2. **\`src/lib/fuel.ts\`** (defensive) — \`dominantFuel\` and \`fuelShare\` now map \`region.kind === "geo"\` → hydro bucket. The 3-way fuel scheme intentionally collapses geothermal into hydro (both always-on baseload renewables, narratively grouped). Previously \`kind: "geo"\` fell through to the \`"solar"\` default — which would have been wrong even without the country-fuelShare bug.

## Regression coverage

\`tests/fuel-attribution.test.ts\` — 7 new tests that lock in:
- \`kind=wind\` → \`wind\`
- \`kind=solar\` → \`solar\`
- \`kind=hydro\` → \`hydro\`
- \`kind=geo\` → \`hydro\` (geothermal collapses to hydro bucket)
- \`fuelShare\` returns 1 for the matched fuel and 0 for others, including \`geo\` → 1 for hydro
- \`kind=mixed\` with \`fuelShare\` still returns the dominant share (existing behaviour preserved)

## Result

Three NZ regions now resolve to three distinct fuels:
- new-zealand-wind → wind colour (teal)
- new-zealand-solar → solar colour (yellow)
- new-zealand-geo → hydro colour (pale blue)

## Gate sweep

| Gate | Result |
|---|---|
| typecheck | ✓ |
| vitest | 463/463 ✓ (456 + 7 new) |
| tier-coherence | 221 records ✓ |
| tally-golden | 383 = 155/9/1/6/8/204 ✓ |
| docs-drift | ✓ |
| validate | ✓ |
| build | ✓ |

## Test plan

- [ ] On Vercel preview / prod, rotate to NZ. Three pillars: wind=teal, solar=yellow, geo=pale-blue
- [ ] Click each → side panel shows correct \`new-zealand-wind\`, \`-solar\`, \`-geo\` ids respectively
- [ ] Hotspot panel: NZ contributions split correctly across wind / solar / hydro buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)