### PR TITLE
fix(loaders): strip country-level fuelShare from per-fuel emissions (CAISO, ERCOT, North Sea, Turkey, EIA ISOs)

### DIFF
--- a/src/data/caiso.json.ts
+++ b/src/data/caiso.json.ts
@@ -66,7 +66,6 @@ export function parseCaisoPerFuel(
       lastUpdated: solarLast,
       lastSuccessAt: solarLast,
       sourceNote: `EIA CISO solar × ${(SOLAR_RATE * 100).toFixed(2)}% calibrated curtailment (CAISO 2024: 3.4 TWh / 80 TWh)`,
-      fuelShare,
     },
     wind: {
       regionId: "caiso-wind",
@@ -77,7 +76,6 @@ export function parseCaisoPerFuel(
       lastUpdated: windLast,
       lastSuccessAt: windLast,
       sourceNote: `EIA CISO wind × ${(WIND_RATE * 100).toFixed(1)}% calibrated curtailment (CAISO 2024: 0.5 TWh / 12 TWh)`,
-      fuelShare,
     },
   };
 }
@@ -164,7 +162,6 @@ export function parseCaisoOasisCurtailmentCsvPerFuel(
       lastUpdated: solarLast,
       lastSuccessAt: solarLast,
       sourceNote: `CAISO OASIS SLD_REN_CURTAIL direct (observed 30d split: solar ${(fuelShare.solar * 100).toFixed(0)}% / wind ${(fuelShare.wind * 100).toFixed(0)}%)`,
-      fuelShare,
     },
     wind: {
       regionId: "caiso-wind",
@@ -175,7 +172,6 @@ export function parseCaisoOasisCurtailmentCsvPerFuel(
       lastUpdated: windLast,
       lastSuccessAt: windLast,
       sourceNote: `CAISO OASIS SLD_REN_CURTAIL direct (observed 30d split: solar ${(fuelShare.solar * 100).toFixed(0)}% / wind ${(fuelShare.wind * 100).toFixed(0)}%)`,
-      fuelShare,
     },
   };
 }

--- a/src/data/ercot.json.ts
+++ b/src/data/ercot.json.ts
@@ -72,7 +72,6 @@ export function parseErcotPerFuel(
       lastUpdated: windWestLast,
       lastSuccessAt: windWestLast,
       sourceNote: `EIA ERCO wind × ${(WIND_RATE * 100).toFixed(2)}% calibrated curtailment, illustrative 66% West/Panhandle split`,
-      fuelShare,
     },
     "ercot-west-solar": {
       regionId: "ercot-west-solar",
@@ -83,7 +82,6 @@ export function parseErcotPerFuel(
       lastUpdated: solarWestLast,
       lastSuccessAt: solarWestLast,
       sourceNote: `EIA ERCO solar × ${(SOLAR_RATE * 100).toFixed(1)}% calibrated curtailment, illustrative 66% West/Panhandle split`,
-      fuelShare,
     },
     "ercot-east-wind": {
       regionId: "ercot-east-wind",
@@ -94,7 +92,6 @@ export function parseErcotPerFuel(
       lastUpdated: windEastLast,
       lastSuccessAt: windEastLast,
       sourceNote: `EIA ERCO wind × ${(WIND_RATE * 100).toFixed(2)}% calibrated curtailment, illustrative 34% East/Central split`,
-      fuelShare,
     },
     "ercot-east-solar": {
       regionId: "ercot-east-solar",
@@ -105,7 +102,6 @@ export function parseErcotPerFuel(
       lastUpdated: solarEastLast,
       lastSuccessAt: solarEastLast,
       sourceNote: `EIA ERCO solar × ${(SOLAR_RATE * 100).toFixed(1)}% calibrated curtailment, illustrative 34% East/Central split`,
-      fuelShare,
     },
   };
 }
@@ -171,14 +167,16 @@ function adaptErcotCache(cached: unknown): ErcotPerFuel {
     base: RegionData,
     zoneId: "ercot-east" | "ercot-west",
   ) => {
+    // Strip any aggregate fuelShare from the base when scaling to a per-fuel
+    // slice — see eia-iso.ts adapter for the rationale.
+    const { fuelShare: _baseFuelShare, ...baseStripped } = base;
     const make = (share: number, fuel: "wind" | "solar"): RegionData => ({
-      ...base,
+      ...baseStripped,
       regionId: `${zoneId}-${fuel}`,
       profile: base.profile.map((g) => g * share),
       latestProfile: base.latestProfile ? base.latestProfile.map((g) => g * share) : null,
       peakGW: (base.peakGW ?? 0) * share,
       totalTWh: (base.totalTWh ?? 0) * share,
-      fuelShare: split,
       sourceNote: `${base.sourceNote ?? ""}${note}`,
     });
     return { wind: make(split.wind, "wind"), solar: make(split.solar, "solar") };

--- a/src/data/north-sea.json.ts
+++ b/src/data/north-sea.json.ts
@@ -110,7 +110,6 @@ const run = async (): Promise<{ wind: RegionData; solar: RegionData }> => {
       lastUpdated,
       lastSuccessAt: lastUpdated,
       sourceNote: noteBase + " — wind share",
-      ...(fuelShare ? { fuelShare } : {}),
     },
     solar: {
       regionId: "north-sea-solar",
@@ -121,7 +120,6 @@ const run = async (): Promise<{ wind: RegionData; solar: RegionData }> => {
       lastUpdated,
       lastSuccessAt: lastUpdated,
       sourceNote: noteBase + " — solar share",
-      ...(fuelShare ? { fuelShare } : {}),
     },
   };
 };

--- a/src/data/turkey.json.ts
+++ b/src/data/turkey.json.ts
@@ -105,7 +105,6 @@ export function buildTurkeyPerFuelData(
       lastUpdated,
       lastSuccessAt: lastUpdated,
       sourceNote: noteStr + " — wind share",
-      ...(fuelShare ? { fuelShare } : {}),
     },
     solar: {
       regionId: "turkey-solar",
@@ -116,7 +115,6 @@ export function buildTurkeyPerFuelData(
       lastUpdated,
       lastSuccessAt: lastUpdated,
       sourceNote: noteStr + " — solar share",
-      ...(fuelShare ? { fuelShare } : {}),
     },
   };
 }
@@ -127,10 +125,16 @@ export function buildTurkeyData(
   sourceNote = "EPIAS Transparency dashboard realtime-generation wind+solar",
 ): RegionData {
   const { wind, solar } = buildTurkeyPerFuelData(response, sourceNote);
-  // Return combined for backward compat
-  const { points } = parseEpiasDashboard(response);
+  // Return combined for backward compat. The aggregate (mixed) variant
+  // legitimately carries fuelShare; per-fuel variants do not (per the
+  // pillar-base / colour invariant — see tests/fuel-attribution.test.ts).
+  const { points, windMwTotal, solarMwTotal } = parseEpiasDashboard(response);
   const lastUpdated = wind.lastUpdated;
   const fuelTotal = (wind.totalTWh + solar.totalTWh);
+  const denom = windMwTotal + solarMwTotal;
+  const fuelShare = denom > 0
+    ? { wind: windMwTotal / denom, solar: solarMwTotal / denom }
+    : undefined;
   return {
     regionId: "turkey",
     profile: timeOfDayAverageGW(points),
@@ -140,7 +144,7 @@ export function buildTurkeyData(
     lastUpdated,
     lastSuccessAt: lastUpdated,
     sourceNote: wind.sourceNote ?? sourceNote,
-    fuelShare: wind.fuelShare,
+    ...(fuelShare ? { fuelShare } : {}),
   };
 }
 

--- a/src/lib/eia-iso.ts
+++ b/src/lib/eia-iso.ts
@@ -66,14 +66,17 @@ export function adaptCachedAggregateToPerFuel(
 
   const agg = cached as RegionData;
   const note = ` [stale-cache: aggregate split via fallback adapter — replaced on next loader regen]`;
+  // Strip aggregate's fuelShare (a country/zone-level mix) when scaling
+  // down to a per-fuel slice. dominantFuel must derive from region.kind,
+  // not from a shared mix that would collapse all fuels to one colour.
+  const { fuelShare: _aggFuelShare, ...aggBase } = agg;
   const scale = (share: number, suffix: "wind" | "solar"): RegionData => ({
-    ...agg,
+    ...aggBase,
     regionId: `${regionId}-${suffix}`,
     profile: agg.profile.map((g) => g * share),
     latestProfile: agg.latestProfile ? agg.latestProfile.map((g) => g * share) : null,
     peakGW: (agg.peakGW ?? 0) * share,
     totalTWh: (agg.totalTWh ?? 0) * share,
-    fuelShare: fallbackSplit,
     sourceNote: `${agg.sourceNote ?? ""}${note}`,
   });
 
@@ -126,7 +129,6 @@ export function parseEiaIsoRegionPerFuel(
     lastUpdated: windLast,
     lastSuccessAt: windLast,
     sourceNote: `EIA ${config.respondent} wind × ${(config.windRate * 100).toFixed(1)}% calibrated curtailment (observed 30d share: wind ${(fuelShare.wind * 100).toFixed(0)}%)`,
-    fuelShare,
   };
 
   const solar: RegionData = {
@@ -138,7 +140,6 @@ export function parseEiaIsoRegionPerFuel(
     lastUpdated: solarLast,
     lastSuccessAt: solarLast,
     sourceNote: `EIA ${config.respondent} solar × ${(config.solarRate * 100).toFixed(1)}% calibrated curtailment (observed 30d share: solar ${(fuelShare.solar * 100).toFixed(0)}%)`,
-    fuelShare,
   };
 
   return { wind, solar };

--- a/tests/data/bpa.test.ts
+++ b/tests/data/bpa.test.ts
@@ -20,6 +20,7 @@ describe("bpa parser (EIA proxy)", () => {
     expect(result.solar.peakGW).toBeCloseTo(Math.max(...result.solar.profile), 3);
     expect(result.wind.totalTWh).toBeGreaterThan(0);
     expect(result.solar.totalTWh).toBeGreaterThan(0);
-    expect((result.wind.fuelShare?.wind ?? 0) + (result.wind.fuelShare?.solar ?? 0)).toBeCloseTo(1, 6);
+    expect(result.wind.fuelShare).toBeUndefined();
+    expect(result.solar.fuelShare).toBeUndefined();
   });
 });

--- a/tests/data/caiso.test.ts
+++ b/tests/data/caiso.test.ts
@@ -44,6 +44,14 @@ describe("caiso parser (EIA proxy)", () => {
     expect(result.wind.sourceNote).toContain("4.2");
   });
 
+  it("does not attach a country-level fuelShare to per-fuel regions", () => {
+    // Per-fuel regions must derive colour/attribution from region.kind, not
+    // from a shared country mix — see tests/fuel-attribution.test.ts.
+    const result = parseCaisoPerFuel(fixture);
+    expect(result.wind.fuelShare).toBeUndefined();
+    expect(result.solar.fuelShare).toBeUndefined();
+  });
+
   it("applies the correct per-fuel rates", () => {
     const result = parseCaisoPerFuel(fixture);
     const fixtureData = fixture.response.data as Array<{ value: string }>;

--- a/tests/data/ercot.test.ts
+++ b/tests/data/ercot.test.ts
@@ -58,4 +58,14 @@ describe("ercot parser (EIA proxy)", () => {
     expect(result["ercot-west-wind"].sourceNote).toContain("66%");
     expect(result["ercot-east-wind"].sourceNote).toContain("34%");
   });
+
+  it("does not attach a country-level fuelShare to per-fuel regions", () => {
+    // Per-fuel regions must derive colour/attribution from region.kind, not
+    // from a shared country mix — see tests/fuel-attribution.test.ts.
+    const result = parseErcotPerFuel(fixture);
+    expect(result["ercot-west-wind"].fuelShare).toBeUndefined();
+    expect(result["ercot-west-solar"].fuelShare).toBeUndefined();
+    expect(result["ercot-east-wind"].fuelShare).toBeUndefined();
+    expect(result["ercot-east-solar"].fuelShare).toBeUndefined();
+  });
 });

--- a/tests/data/iso-ne.test.ts
+++ b/tests/data/iso-ne.test.ts
@@ -20,6 +20,7 @@ describe("iso-ne parser (EIA proxy)", () => {
     expect(result.solar.peakGW).toBeCloseTo(Math.max(...result.solar.profile), 3);
     expect(result.wind.totalTWh).toBeGreaterThan(0);
     expect(result.solar.totalTWh).toBeGreaterThan(0);
-    expect((result.wind.fuelShare?.wind ?? 0) + (result.wind.fuelShare?.solar ?? 0)).toBeCloseTo(1, 6);
+    expect(result.wind.fuelShare).toBeUndefined();
+    expect(result.solar.fuelShare).toBeUndefined();
   });
 });

--- a/tests/data/miso.test.ts
+++ b/tests/data/miso.test.ts
@@ -20,6 +20,7 @@ describe("miso parser (EIA proxy)", () => {
     expect(result.solar.peakGW).toBeCloseTo(Math.max(...result.solar.profile), 3);
     expect(result.wind.totalTWh).toBeGreaterThan(0);
     expect(result.solar.totalTWh).toBeGreaterThan(0);
-    expect((result.wind.fuelShare?.wind ?? 0) + (result.wind.fuelShare?.solar ?? 0)).toBeCloseTo(1, 6);
+    expect(result.wind.fuelShare).toBeUndefined();
+    expect(result.solar.fuelShare).toBeUndefined();
   });
 });

--- a/tests/data/nyiso.test.ts
+++ b/tests/data/nyiso.test.ts
@@ -20,6 +20,7 @@ describe("nyiso parser (EIA proxy)", () => {
     expect(result.solar.peakGW).toBeCloseTo(Math.max(...result.solar.profile), 3);
     expect(result.wind.totalTWh).toBeGreaterThanOrEqual(0);
     expect(result.solar.totalTWh).toBeGreaterThanOrEqual(0);
-    expect((result.wind.fuelShare?.wind ?? 0) + (result.wind.fuelShare?.solar ?? 0)).toBeCloseTo(1, 6);
+    expect(result.wind.fuelShare).toBeUndefined();
+    expect(result.solar.fuelShare).toBeUndefined();
   });
 });

--- a/tests/data/pjm.test.ts
+++ b/tests/data/pjm.test.ts
@@ -20,6 +20,7 @@ describe("pjm parser (EIA proxy)", () => {
     expect(result.solar.peakGW).toBeCloseTo(Math.max(...result.solar.profile), 3);
     expect(result.wind.totalTWh).toBeGreaterThan(0);
     expect(result.solar.totalTWh).toBeGreaterThan(0);
-    expect((result.wind.fuelShare?.wind ?? 0) + (result.wind.fuelShare?.solar ?? 0)).toBeCloseTo(1, 6);
+    expect(result.wind.fuelShare).toBeUndefined();
+    expect(result.solar.fuelShare).toBeUndefined();
   });
 });

--- a/tests/data/spp.test.ts
+++ b/tests/data/spp.test.ts
@@ -20,6 +20,7 @@ describe("spp parser (EIA proxy)", () => {
     expect(result.solar.peakGW).toBeCloseTo(Math.max(...result.solar.profile), 3);
     expect(result.wind.totalTWh).toBeGreaterThan(0);
     expect(result.solar.totalTWh).toBeGreaterThan(0);
-    expect((result.wind.fuelShare?.wind ?? 0) + (result.wind.fuelShare?.solar ?? 0)).toBeCloseTo(1, 6);
+    expect(result.wind.fuelShare).toBeUndefined();
+    expect(result.solar.fuelShare).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Same bug class as PR #64

PR #64 fixed the visible "all three NZ pillars same colour" bug. The same root cause silently affects 5 other loaders and ~10 region pairs — the bug just looks subtler because 2-way pairs still produce two distinct colours overall, but one pillar is painted in the wrong fuel's colour.

## Mechanism

Each affected loader computes a country-level \`fuelShare = {wind, solar}\` and attaches the **same** fuelShare to both per-fuel region emissions. \`dominantFuel\` then ranks by max share, so:

- If wind > solar in the country mix → both pair regions render in **wind** colour (the solar pillar looks wrong)
- If solar > wind → both render in **solar** colour (the wind pillar looks wrong)

It also misroutes hotspot column placement: each region's GW was fragmented across both fuel columns according to the country mix instead of fully attributed to its kind.

## Loaders cleaned up

| Loader | Per-fuel regions affected |
|---|---|
| \`src/data/caiso.json.ts\` | caiso-wind / caiso-solar (both EIA + OASIS paths) |
| \`src/data/ercot.json.ts\` | ercot-east-wind/-solar, ercot-west-wind/-solar (+ stale-cache adapter) |
| \`src/data/north-sea.json.ts\` | north-sea-wind / north-sea-solar |
| \`src/data/turkey.json.ts\` | turkey-wind / turkey-solar |
| \`src/lib/eia-iso.ts\` | \`parseEiaIsoRegionPerFuel\` + \`adaptCachedAggregateToPerFuel\` — used by **MISO, SPP, PJM, NYISO-rest, ISO-NE-rest, BPA** |

## What's preserved

Aggregate / mixed-region emissions still legitimately carry \`fuelShare\`:
- \`parseEiaIsoRegion\` (legacy aggregate, e.g. \`regionId="miso"\`)
- \`buildTurkeyData\` (legacy aggregate, \`regionId="turkey"\`)

These represent multi-fuel data for a single region; dominantFuel's fuelShare branch is the correct path for them. The Turkey aggregate now derives fuelShare independently from the parsed mw totals (was extracting from \`wind.fuelShare\`, which is now undefined).

## Test updates

- \`tests/data/{bpa,iso-ne,miso,nyiso,pjm,spp}.test.ts\` — inverted the previous \`fuelShare sums to 1\` assertion to assert \`fuelShare === undefined\` on per-fuel regions
- \`tests/data/{caiso,ercot}.test.ts\` — added new "no country-level fuelShare on per-fuel regions" assertion

## Gate sweep

| Gate | Result |
|---|---|
| typecheck | ✓ |
| vitest | 465/465 ✓ |
| tier-coherence | 221 records ✓ |
| tally-golden | 383 = 155/9/1/6/8/204 ✓ |
| docs-drift | ✓ |
| validate | ✓ |
| build | ✓ |

## Test plan

- [ ] On Vercel preview / prod: every per-fuel pair displays two correctly-coloured pillars
  - caiso-wind = teal, caiso-solar = yellow
  - ercot-{east,west}-wind = teal, ercot-{east,west}-solar = yellow
  - turkey-wind = teal, turkey-solar = yellow
  - MISO/SPP/PJM/NYISO-rest/ISO-NE-rest/BPA wind = teal, solar = yellow
  - north-sea-wind = teal, north-sea-solar = yellow
- [ ] Hotspot panel: each per-fuel region's GW lands fully in its own fuel column (not split across both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)