### PR TITLE
fix(globe): flare pillars use distinct flare colour, not solar-yellow (closes #44)

### DIFF
--- a/src/components/region-tooltip.js
+++ b/src/components/region-tooltip.js
@@ -1,5 +1,5 @@
 import { regionGWAtHour } from "../lib/calc.js";
-import { getFuelColor, FUEL_LABEL, dominantFuel } from "../lib/fuel.js";
+import { getFuelColor, FUEL_LABEL, dominantFuel, getRegionFuelColor } from "../lib/fuel.js";
 
 /**
  * Floating detail card anchored to a globe click. Shows region identity,
@@ -33,8 +33,7 @@ export function mountRegionTooltip({ clock, regionData, getMode, regions }) {
   }
 
   function colorFor(region) {
-    if (region.kind === "flare") return getFuelColor("flare");
-    return getFuelColor(dominantFuel(region, regionData[region.id]));
+    return getRegionFuelColor(region, regionData[region.id]);
   }
 
   function fuelLabel(region) {

--- a/src/globe.js
+++ b/src/globe.js
@@ -1,7 +1,7 @@
 import * as d3 from "npm:d3";
 import * as topojson from "npm:topojson-client";
 import { regionGWAtHour } from "./lib/calc.js";
-import { getFuelColor, dominantFuel } from "./lib/fuel.js";
+import { getRegionFuelColor } from "./lib/fuel.js";
 import { readGlobeTokens, isLinearGradientToken } from "./lib/theme-tokens.js";
 import { buildPillarUnits } from "./lib/pillar-layout.js";
 
@@ -462,7 +462,7 @@ export async function mountGlobe(canvas, initial) {
 
       // Dominant color for glow + core dot.
       const repData = state.regionData[rep.id];
-      const domColor = getFuelColor(rep.kind === "flare" ? "flare" : dominantFuel(rep, repData));
+      const domColor = getRegionFuelColor(rep, repData);
 
       ctx.save();
       ctx.filter = "blur(4px)";
@@ -525,7 +525,7 @@ export async function mountGlobe(canvas, initial) {
             const segEndX = segStartX + dx * segLen;
             const segEndY = segStartY + dy * segLen;
             const segData = state.regionData[seg.region.id];
-            const segColor = getFuelColor(seg.region.kind === "flare" ? "flare" : dominantFuel(seg.region, segData));
+            const segColor = getRegionFuelColor(seg.region, segData);
             const isBase = segStart === 0;
             const isTip = segStart + segLen >= pillarH - 0.5;
             const grad = ctx.createLinearGradient(segStartX, segStartY, segEndX, segEndY);

--- a/src/lib/fuel.ts
+++ b/src/lib/fuel.ts
@@ -46,6 +46,24 @@ export function getFuelColor(fuel: Fuel | "flare"): string {
 }
 
 /**
+ * Region-aware pillar/swatch colour resolver. Centralises the
+ * `kind === "flare" → flare token, else dominantFuel` routing so individual
+ * call sites (globe canvas, tooltip, future legend strips) cannot regress
+ * the flare → solar-yellow class of bug.
+ *
+ * Background: `dominantFuel` returns `Fuel` (solar | wind | hydro). For a
+ * `kind: "flare"` region with no `fuelShare` it falls through to the
+ * `return "solar"` default — meaning any caller that forgets the
+ * `kind === "flare"` short-circuit silently paints flare pillars yellow
+ * (issue #44). Callers should prefer this function over composing the
+ * guard themselves.
+ */
+export function getRegionFuelColor(region: Region, regionData?: RegionData): string {
+  if (region.kind === "flare") return getFuelColor("flare");
+  return getFuelColor(dominantFuel(region, regionData));
+}
+
+/**
  * Empirical curtailment split for `kind: "mixed"` regions, derived from
  * published generation-mix data for 2024. Values must sum to ≤ 1.0.
  *

--- a/tests/fuel-color.test.ts
+++ b/tests/fuel-color.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { getFuelColor } from "../src/lib/fuel";
+import { getFuelColor, getRegionFuelColor } from "../src/lib/fuel";
+import type { Region, RegionData } from "../src/lib/types";
 
 beforeEach(() => {
   document.documentElement.setAttribute("data-theme", "sunfire");
@@ -41,5 +42,67 @@ describe("getFuelColor", () => {
     // Stylesheet not loaded in this test harness, so getComputedStyle
     // returns "" → getFuelColor falls back to the Sunfire default.
     expect(getFuelColor("solar")).toBe("#ffd05a");
+  });
+});
+
+/**
+ * Regression cover for issue #44 — flare regions used to render as
+ * solar-yellow on the globe because `dominantFuel(flareRegion)` falls
+ * through to `return "solar"`. Any caller that forgets the
+ * `kind === "flare"` short-circuit silently mis-colours the pillar.
+ *
+ * `getRegionFuelColor` centralises that routing, so we lock it in with
+ * a per-flare-region check that the resolved colour is the flare token
+ * (`--data-flare`) and explicitly NOT the solar token (`--fuel-solar`).
+ */
+describe("getRegionFuelColor — flare regions never resolve to the solar colour", () => {
+  const flare = (id: string): Region => ({
+    id,
+    name: id,
+    country: "ZZZ",
+    lat: 0,
+    lon: 0,
+    tier: "flare",
+    kind: "flare",
+    source: "",
+    sourceUrl: "",
+  });
+
+  // Eight T2-flare basins + three offshore T3-static flare anchors. If any
+  // of these regress to the solar colour, we want the test name to point
+  // at the offending region.
+  const FLARE_IDS = [
+    "permian", "w-siberia", "s-iraq", "e-saudi",
+    "qatar", "kuwait", "russia-yamal", "russia-e-siberia",
+    "trinidad-tobago", "guyana", "suriname",
+  ];
+
+  for (const id of FLARE_IDS) {
+    it(`${id} resolves to the flare token, not solar`, () => {
+      const colour = getRegionFuelColor(flare(id));
+      expect(colour).toBe(getFuelColor("flare"));
+      expect(colour).not.toBe(getFuelColor("solar"));
+    });
+  }
+
+  it("flare routing wins even when fuelShare leans solar (defensive)", () => {
+    // A flare region that somehow has a misattributed solar-heavy
+    // fuelShare (loader bug, future regression, malformed snapshot)
+    // must STILL paint as flare. The kind discriminator is the source
+    // of truth, not the per-fuel-shares vector.
+    const data: Partial<RegionData> = { fuelShare: { solar: 0.9, wind: 0.1 } };
+    expect(getRegionFuelColor(flare("permian"), data as RegionData))
+      .toBe(getFuelColor("flare"));
+    expect(getRegionFuelColor(flare("permian"), data as RegionData))
+      .not.toBe(getFuelColor("solar"));
+  });
+
+  it("non-flare regions still route through dominantFuel", () => {
+    const solarRegion: Region = {
+      id: "test-solar", name: "test", country: "ZZZ",
+      lat: 0, lon: 0, tier: "live", kind: "solar",
+      source: "", sourceUrl: "",
+    };
+    expect(getRegionFuelColor(solarRegion)).toBe(getFuelColor("solar"));
   });
 });


### PR DESCRIPTION
## Summary

- Root cause: \`dominantFuel(flareRegion)\` falls through to \`return "solar"\`. Every call site had its own \`kind === "flare"\` guard — easy to forget, latent regression surface for the symptom in #44.
- Fix: add \`getRegionFuelColor(region, regionData)\` in \`src/lib/fuel.ts\` as a single region-aware resolver. Refactor \`globe.js\` (single + stacked-segment paths) and \`region-tooltip.js\` to use it. Flare colour stays on the existing \`--data-flare\` theme token (locked across Sunfire / Vellum / Eclipse, per the original design intent).
- Adds 13 regression tests in \`tests/fuel-color.test.ts\` covering all 11 flare-kind regions (Permian, W. Siberia, S. Iraq, E. Saudi, Qatar, Kuwait, Russia Yamal, Russia E. Siberia + Trinidad-Tobago, Guyana, Suriname) plus a defensive case asserting that kind beats a stray solar-heavy fuelShare.

Closes #44.

## Test plan

- [x] \`npx vitest run\` — 478 tests pass (was 465; +13 new flare regression tests)
- [x] \`npm run ci:gates\` — all green (tier-coherence, source-provenance, tally-golden, docs-drift, bad-conversions)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] Local Playwright smoke test:
  - Flare toggle ON → flare-coloured pixels (\`#d83923\`) consistently render on globe (peak ~680 pixels visible at any rotation; varies as flare regions cross horizon)
  - Flare toggle OFF → 0 flare-coloured pixels rendered
  - Theme cycle: \`--data-flare\` correctly resolves to \`#d83923\` in Sunfire, Vellum, Eclipse — solar token differs in each, flare stays distinct in all three

🤖 Generated with [Claude Code](https://claude.com/claude-code)