### PR TITLE
chore(style): use --brand token for tooltip + footer link colours

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1143,7 +1143,7 @@ main table {
   border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 .region-tooltip-source a {
-  color: var(--teal-400, #3fc1be);
+  color: var(--brand);
   text-decoration: none;
 }
 .region-tooltip-source a:hover {
@@ -1160,7 +1160,7 @@ main table {
   font-size: 11px;
 }
 .region-tooltip-footer a {
-  color: var(--teal-400, #3fc1be);
+  color: var(--brand);
   text-decoration: none;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1458,7 +1458,7 @@ main table {
 }
 
 .app-footer .caption a {
-  color: var(--teal-400, #3fc1be);
+  color: var(--brand);
   text-decoration: none;
 }
 .app-footer .caption a:hover { text-decoration: underline; }


### PR DESCRIPTION
## Summary

Three remaining hardcoded `var(--teal-400, #3fc1be)` references swapped to `var(--brand)` so theme tokens drive link colour consistently. Visual outcome already verified by Simon.

## Locations

- `src/style.css:1146` — `.region-tooltip-source a`
- `src/style.css:1163` — `.region-tooltip-footer a`
- `src/style.css:1461` — `.app-footer .caption a`

The remaining two `--teal-400` references in `src/style.css` (~lines 1736, 1808) were intentionally left untouched per Simon's selection.

## Test plan

- [x] Token swap; no logic / layout / structural change
- [x] Visual verification by Simon prior to commit
- [ ] CI green