### PR TITLE
feat: wire 9 Japan regional loaders into dashboard

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -41,7 +41,7 @@ const HOTSPOT_LIST_LIMIT = 50;
 // Initialise the loading-progress terminal before fetches start.
 // trackFile() wraps each FileAttachment promise so the terminal updates
 // as each source resolves (HTTP/2 delivers them in parallel).
-const _LOADER_FILE_COUNT = 103;
+const _LOADER_FILE_COUNT = 112;
 initLoaderProgress(REGIONS.length, _LOADER_FILE_COUNT);
 
 // Fetch all region data in parallel. Prior to this, every FileAttachment
@@ -53,7 +53,9 @@ const [
   entsoe, aemo, belgium, france, denmark, newZealand, norway, atacama,
   chileWind, statics, anchor, northSea, brazilNE, ontario, alberta,
   ireland, peru, southAfrica, argentina, uruguay, paraguay, mexico,
-  japanKyushu, vietnam, thailand, indiaRajasthan, cyprus, ethiopia, kazakhstan,
+  japanChubu, japanChugoku, japanHokkaido, japanHokuriku, japanKansai,
+  japanKyushu, japanOkinawa, japanShikoku, japanTepco, japanTohoku,
+  vietnam, thailand, indiaRajasthan, cyprus, ethiopia, kazakhstan,
   honduras, jeju, kenya, egypt, morocco, namibia, waSwis, ntPilbara,
   indonesia, malaysia, philippines, southKorea, russiaMainland, taiwan, jordan,
   saudiSolar, uae, oman, israel, innerMongolia, gansu, qinghai, ningxia,
@@ -98,7 +100,16 @@ const [
   trackFile(FileAttachment("data/uruguay.json").json(),          "Uruguay"),
   trackFile(FileAttachment("data/paraguay.json").json(),         "Paraguay"),
   trackFile(FileAttachment("data/mexico.json").json(),           "Mexico"),
+  trackFile(FileAttachment("data/japan-chubu.json").json(),      "Japan Chubu"),
+  trackFile(FileAttachment("data/japan-chugoku.json").json(),    "Japan Chugoku"),
+  trackFile(FileAttachment("data/japan-hokkaido.json").json(),   "Japan Hokkaido"),
+  trackFile(FileAttachment("data/japan-hokuriku.json").json(),   "Japan Hokuriku"),
+  trackFile(FileAttachment("data/japan-kansai.json").json(),     "Japan Kansai"),
   trackFile(FileAttachment("data/japan-kyushu.json").json(),     "Japan Kyushu"),
+  trackFile(FileAttachment("data/japan-okinawa.json").json(),    "Japan Okinawa"),
+  trackFile(FileAttachment("data/japan-shikoku.json").json(),    "Japan Shikoku"),
+  trackFile(FileAttachment("data/japan-tepco.json").json(),      "Japan TEPCO"),
+  trackFile(FileAttachment("data/japan-tohoku.json").json(),     "Japan Tohoku"),
   trackFile(FileAttachment("data/vietnam.json").json(),          "Vietnam"),
   trackFile(FileAttachment("data/thailand.json").json(),         "Thailand"),
   trackFile(FileAttachment("data/india-rajasthan.json").json(),  "India Rajasthan"),
@@ -411,7 +422,16 @@ const regionData = {
   uruguay,
   paraguay,
   mexico,
-  "japan-kyushu": japanKyushu,
+  "japan-chubu":    japanChubu,
+  "japan-chugoku":  japanChugoku,
+  "japan-hokkaido": japanHokkaido,
+  "japan-hokuriku": japanHokuriku,
+  "japan-kansai":   japanKansai,
+  "japan-kyushu":   japanKyushu,
+  "japan-okinawa":  japanOkinawa,
+  "japan-shikoku":  japanShikoku,
+  "japan-tepco":    japanTepco,
+  "japan-tohoku":   japanTohoku,
   vietnam,
   thailand,
   "india-rajasthan": indiaRajasthan,


### PR DESCRIPTION
## Summary

Closes BLOCKER #5 from the 2026-05-10 architect audit.

`src/lib/regions.ts` declares 10 Japan regional grid operators with `tier: "live"` and verified provenance, but `src/index.md` only fetched and wired `japan-kyushu`. The other 9 (Chubu, Chugoku, Hokkaido, Hokuriku, Kansai, Okinawa, Shikoku, TEPCO, Tohoku) silently rendered as no-data despite paper-claimed live coverage — every region had a working loader, a passing test, but no fetch + wiring path.

This PR adds the missing fetches and wirings. One file changed: `src/index.md` (+23/-3).

## Verification

- [x] `npm test` — 509/509
- [x] `npm run typecheck` — clean
- [x] `npm run ci:gates` — all 6 gates pass against committed state
- [x] `npm run build` — exit 0; 9 new loaders ran end-to-end
- [x] Spec compliance reviewer — clean (after dismissing a false alarm caused by local snapshot regeneration)
- [x] Code quality reviewer — approved, no Critical/Important issues; 2 Minor nits non-blocking

## Known upstream issues (not introduced by this PR; pre-existing)

During the build verification step, three loaders fell through to the `withFallback` resilience layer due to upstream availability:

- `japan-chubu`: DNS ENOTFOUND for `denki-yoho.chuden.jp`
- `japan-tepco`: HTTP 404 on TEPCO's CSV URL
- `japan-hokkaido`: HTTP 404 on today's date-keyed CSV

These are upstream/network conditions today — not bugs in the wiring. The committed `data/snapshots/last-good/` for Chubu and TEPCO carry `T1a-live-tso` from when they were last successfully fetched, and the resilience layer will serve those when upstream fails. Worth a separate ticket to investigate whether Chubu's domain has changed; flagging here for visibility rather than silent paper-over.

## Test plan

- [ ] Vercel preview shows 9 new Japan regional pillars rendering with non-zero GW (some via live data, some via cached/last-good fallback)
- [ ] `npm run ci:gates` still green on the merge commit
- [ ] No regression on existing pillars

## Coordination with PR #84

#84 (Phase 1: loader-wiring blockers) and this PR both touch `src/index.md`. Edits are in different regions — destructure list, trackFile list, and regionData wiring sections all have non-overlapping additions. Expect a trivial 3-way merge at integration time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)