### PR TITLE
test: island-polygon overrides for okinawa/jeju/vanuatu

### DIFF
--- a/tests/fixtures/region-polygon-overrides.geo.json
+++ b/tests/fixtures/region-polygon-overrides.geo.json
@@ -1,0 +1,51 @@
+{
+  "$comment": "Per-region polygon overrides for the pillar-base-inside-country containment test. Used when a region's island sits outside its country's 110m-simplified polygon. Each feature's `id` matches a region.id from src/lib/regions.ts. Geometry is a simple bounding box around the island. Outer rings are wound clockwise (lon/lat order) per d3-geo's convention for spherical polygons; with CCW the polygon represents its complement (everything except the box) and the containment check inverts.",
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": "japan-okinawa",
+      "properties": { "name": "Okinawa main island bounding box" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [127.50, 26.00],
+          [127.50, 27.00],
+          [128.50, 27.00],
+          [128.50, 26.00],
+          [127.50, 26.00]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "jeju",
+      "properties": { "name": "Jeju island bounding box" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [126.00, 33.00],
+          [126.00, 33.70],
+          [127.00, 33.70],
+          [127.00, 33.00],
+          [126.00, 33.00]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": "vanuatu",
+      "properties": { "name": "Vanuatu archipelago bounding box" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [166.00, -20.50],
+          [166.00, -13.00],
+          [170.50, -13.00],
+          [170.50, -20.50],
+          [166.00, -20.50]
+        ]]
+      }
+    }
+  ]
+}

--- a/tests/pillar-country-containment.test.ts
+++ b/tests/pillar-country-containment.test.ts
@@ -249,6 +249,30 @@ for (const feature of featureCollection.features) {
 }
 
 // ---------------------------------------------------------------------------
+// Per-region polygon overrides
+//
+// countries-110m.json drops some islands from their parent-country polygon
+// (Okinawa from JPN, Jeju from KOR, Vanuatu from its own archipelago bounds).
+// Overrides supply a region-specific GeoJSON polygon used in place of the
+// country polygon for the containment check. Coordinates are simple bounding
+// boxes around the island — accuracy beyond "point falls inside box" is not
+// needed for this invariant test.
+// ---------------------------------------------------------------------------
+
+const overridesPath = join(__dirname, "fixtures/region-polygon-overrides.geo.json");
+const overridesCollection = JSON.parse(readFileSync(overridesPath, "utf-8")) as FeatureCollection<
+  Geometry,
+  GeoJsonProperties
+>;
+const regionIdToOverride = new Map<string, Feature<Geometry, GeoJsonProperties>>();
+for (const feature of overridesCollection.features) {
+  const id = feature.id as string | undefined;
+  if (id != null) {
+    regionIdToOverride.set(String(id), feature);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Tolerance: 0.5°
 //
 // We check the exact point AND the four cardinal neighbours at ±0.5°. This
@@ -278,23 +302,14 @@ function isContainedWithTolerance(
 // Build test cases, separating skipped entries
 // ---------------------------------------------------------------------------
 
-type TestCase = { id: string; country: string; lon: number; lat: number };
+type TestCase = {
+  id: string;
+  country: string;
+  lon: number;
+  lat: number;
+  feature: Feature<Geometry, GeoJsonProperties>;
+};
 type SkippedCase = { id: string; country: string; reason: string };
-
-// Known-failing regions from the initial sweep (2026-05-10). Two categories:
-//
-//   ARCHIPELAGO_ISLAND_REGIONS — main-country code points to a polygon that
-//   excludes the actual island (Okinawa is in Japan, but JPN's 110m polygon
-//   is mainland-only; same for Jeju in Korea, Vanuatu's archipelago). The
-//   coordinates are correct; the polygon is the wrong granularity. Marked
-//   `it.skip` until we either switch to higher-resolution topology or add
-//   per-region polygon overrides for these cases.
-//
-const ARCHIPELAGO_ISLAND_REGIONS = new Set<string>([
-  "japan-okinawa",  // Okinawa island, not mainland Japan
-  "jeju",           // Jeju island, not mainland Korea
-  "vanuatu",        // archipelago dropped in 110m simplification
-]);
 
 const testCases: TestCase[] = [];
 const skippedCases: SkippedCase[] = [];
@@ -326,19 +341,17 @@ for (const region of REGIONS) {
     continue;
   }
 
-  if (ARCHIPELAGO_ISLAND_REGIONS.has(region.id)) {
-    // Region's island isn't part of its main-country polygon at 110m resolution.
-    // Coords are correct; polygon granularity is wrong. Skip until higher-res
-    // topology or per-region polygon override is wired in.
-    skippedCases.push({
-      id: region.id,
-      country: region.country,
-      reason: "island region — main-country polygon at 110m excludes this island",
-    });
-    continue;
-  }
+  // Override polygon takes precedence over the country polygon for regions
+  // whose island sits outside the 110m country boundary.
+  const featureToCheck = regionIdToOverride.get(region.id) ?? feature;
 
-  testCases.push({ id: region.id, country: region.country, lon: region.lon, lat: region.lat });
+  testCases.push({
+    id: region.id,
+    country: region.country,
+    lon: region.lon,
+    lat: region.lat,
+    feature: featureToCheck,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -360,9 +373,7 @@ describe("pillar-country-containment", () => {
 
   it.each(testCases)(
     "region $id ($country) at (lon=$lon, lat=$lat) is inside its country polygon",
-    ({ id, country, lon, lat }) => {
-      const numericId = ISO3_TO_NUMERIC[country]!;
-      const feature = numericToFeature.get(numericId)!;
+    ({ id, country, lon, lat, feature }) => {
       const contained = isContainedWithTolerance(feature, lon, lat);
       expect(
         contained,


### PR DESCRIPTION
## Summary

Closes the 3-island skip-list from PR #86. countries-110m.json drops Okinawa from the JPN polygon, Jeju from the KOR polygon, and the Vanuatu archipelago from VUT — so the pillar-base-inside-country test was skipping those three regions despite their coords being correct.

This PR adds a per-region polygon override mechanism. `tests/fixtures/region-polygon-overrides.geo.json` maps `region.id` → custom GeoJSON polygon. The test consults the override map first; falls through to the country polygon if no override exists. Backwards-compatible — regions without overrides are unchanged.

## What got fixed

| Region | Override polygon (bounding box) | Previously |
|---|---|---|
| `japan-okinawa` | (127.5, 26.0) – (128.5, 27.0) | Skipped — JPN polygon excludes Okinawa |
| `jeju` | (126.0, 33.0) – (127.0, 33.7) | Skipped — KOR polygon excludes Jeju |
| `vanuatu` | (166.0, -20.5) – (170.5, -13.0) | Skipped — VUT polygon excludes the archipelago |

Bounding-box geometry is sufficient — accuracy beyond "point falls inside box" is not needed for an invariant test. Switch to higher-resolution topology only if pixel-accurate containment ever matters elsewhere.

## Implementation note

Outer rings are wound clockwise per d3-geo's spherical convention (CCW gives the polygon's complement, which inverts the containment check). Caught during initial wiring when only Vanuatu's larger box failed while Okinawa/Jeju leaked through tolerance — wrote a small probe script to confirm. Documented in the file's `$comment`.

## Verification

- [x] `npm test -- pillar-country-containment` — 356/356 (was 353 active passing + 3 skipped)
- [x] `npm test` — full suite green
- [x] `npm run typecheck` — clean
- [x] `npm run ci:gates` — all 6 gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)