### PR TITLE
fix: denmark wiring (PROD-DOWN) — 4 fuel×zone keys to match regions.ts

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -337,12 +337,22 @@ const regionData = {
   ...france,
   "netherlands-wind": entsoe["netherlands-wind"],
   "netherlands-solar": entsoe["netherlands-solar"],
-  // Denmark split by Energinet PriceArea. DK1 (Jutland/Fyn) hosts most
-  // onshore wind and interconnects with Germany; DK2 (Zealand) is across
-  // Øresund from Sweden. 75/25 approximates DK1's share of combined
-  // wind+solar generation.
-  "denmark-west": splitRegion(denmark, "denmark-west", 0.75, "DK1 (Jutland/Fyn) share of Energinet wind+solar"),
-  "denmark-east": splitRegion(denmark, "denmark-east", 0.25, "DK2 (Zealand) share of Energinet wind+solar"),
+  // Denmark split by Energinet PriceArea × fuel. DK1 (Jutland/Fyn) hosts
+  // most onshore wind and interconnects with Germany; DK2 (Zealand) is
+  // across Øresund from Sweden. Zone share: 75% DK1 / 25% DK2 of combined
+  // wind+solar generation. Fuel share: observed 30-day split from the
+  // loader's fuelShare field (falls back to 70/30 wind/solar for first
+  // boot before any data has loaded).
+  ...(() => {
+    const wShare = denmark.fuelShare?.wind ?? 0.7;
+    const sShare = denmark.fuelShare?.solar ?? 0.3;
+    return {
+      "denmark-west-wind":  splitRegion(denmark, "denmark-west-wind",  0.75 * wShare, "DK1 wind: 75% zone × observed wind fuel-share"),
+      "denmark-west-solar": splitRegion(denmark, "denmark-west-solar", 0.75 * sShare, "DK1 solar: 75% zone × observed solar fuel-share"),
+      "denmark-east-wind":  splitRegion(denmark, "denmark-east-wind",  0.25 * wShare, "DK2 wind: 25% zone × observed wind fuel-share"),
+      "denmark-east-solar": splitRegion(denmark, "denmark-east-solar", 0.25 * sShare, "DK2 solar: 25% zone × observed solar fuel-share"),
+    };
+  })(),
   "poland-wind": entsoe["poland-wind"],
   "poland-solar": entsoe["poland-solar"],
   "greece-wind": entsoe["greece-wind"],


### PR DESCRIPTION
## PROD-DOWN

Page hangs at "LOADING REGIONS 0/384" because the runtime \`assertCanonicalRegionData\` from PR #84 throws on every page load:

\`\`\`
Error: RegionData does not match canonical REGIONS
  missing: denmark-west-wind, denmark-west-solar, denmark-east-wind, denmark-east-solar
  extra: denmark-east, denmark-west
\`\`\`

## Cause

\`regions.ts\` declares 4 Denmark regions (\`denmark-{west,east}-{wind,solar}\`) but \`index.md\` was wiring only 2 zone-only keys (\`denmark-west\`, \`denmark-east\`). Same Belgium-shape bug class PR #84 was designed to catch — and the strengthened check is doing exactly its job, surfacing it loudly instead of rendering silent zero-GW pillars.

The Denmark loader returns a **single** mixed-fuel \`RegionData\` with a \`fuelShare\` field documenting the observed 30-day wind/solar split (not a Record). The new wiring composes zone-share × fuel-share to produce all 4 keys:

| Key | Ratio | Note |
|---|---|---|
| \`denmark-west-wind\` | 0.75 × wind-share | DK1 wind: 75% zone × observed wind fuel-share |
| \`denmark-west-solar\` | 0.75 × solar-share | DK1 solar: 75% zone × observed solar fuel-share |
| \`denmark-east-wind\` | 0.25 × wind-share | DK2 wind: 25% zone × observed wind fuel-share |
| \`denmark-east-solar\` | 0.25 × solar-share | DK2 solar: 25% zone × observed solar fuel-share |

Falls back to 70/30 wind/solar if \`fuelShare\` is absent on first boot.

## Verification

- [x] \`npm test\` — 827/827
- [x] \`npm run typecheck\` — clean
- [x] \`npm run ci:gates\` — all 6 gates pass
- [x] Reproduced the prod hang in browser; the runtime assert error matches exactly

## Why was this missed

PR #84 reviewer audited shorthand wirings (\`argentina,\` etc.) and \`...spread\` patterns, but missed the explicit \`splitRegion\` calls that produce zone-only keys. \`splitRegion\` was producing valid RegionData values, just under the wrong canonical IDs. The audit's check was for shape mismatch (Record-into-single-key); this was a different kind of mismatch (zone-keyed wiring vs. zone×fuel canonical IDs). Worth a follow-up sweep across all \`splitRegion\` call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)