### PR TITLE
fix(embed): dark scrim behind globe so pillars contrast

### DIFF
--- a/src/embed/globe.md
+++ b/src/embed/globe.md
@@ -33,6 +33,7 @@ pager: false
        text and the page surround use the da-ri.org Sunfire-paper palette so
        this iframe blends into the consuming document. */
     --embed-bg: #F7F7F4;
+    --embed-globe-bg: #0a0f24;
     --embed-fg: #1A2340;
     --embed-fg-muted: #6B7280;
     --embed-rule: #E2E2DC;
@@ -80,6 +81,9 @@ pager: false
     width: 100%;
     aspect-ratio: 16 / 10;
     min-height: 360px;
+    background: var(--embed-globe-bg);
+    border-radius: 6px;
+    overflow: hidden;
   }
 
   #embed-globe-canvas {


### PR DESCRIPTION
## Summary
- Curtailment pillars rising above the globe's limb were disappearing into the off-white embed background.
- Add a dark scrim (\`--embed-globe-bg: #0a0f24\`) on \`.embed-globe-area\` only, clipped with a 6px radius so it reads as a card-within-the-card.
- Key + Bitcoin renewable readout below stay on the off-white surface — they continue to look like paper text.
- No globe.js change needed: the canvas clears to transparent, so the dark parent shows through automatically around the sphere.

## Test plan
- [ ] CI verify passes
- [ ] Open \`/embed/globe\` post-deploy, confirm pillars are visible against the dark scrim and the key + readout still read on the light frame
- [ ] Eyeball Figure 1 in \`docs/dari/paper.html\` (which iframes this) — confirm the new look integrates with the paper layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)