### PR TITLE
fix(embed): readout says 'curtailed renewables' not just 'renewables'

### DIFF
--- a/src/embed/globe.md
+++ b/src/embed/globe.md
@@ -21,7 +21,7 @@ pager: false
       </ul>
       <p class="embed-readout">
         <strong id="embed-pct">—%</strong>
-        <span>of Bitcoin network powered by renewables right now</span>
+        <span>of Bitcoin network powered by curtailed renewables right now</span>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
Single-word fix to the globe embed readout so the displayed text matches the underlying metric.

The % computed by the embed is the share of the Bitcoin network's current hashrate that today's *curtailment* alone could power — not the share of Bitcoin running on all renewable generation. The previous wording ("powered by renewables right now") implied the latter.

Now reads: **"218% of Bitcoin network powered by curtailed renewables right now"** (% live, varies hour by hour).

## Test plan
- [ ] CI verify passes
- [ ] After merge + deploy, refresh paper.html iframe — readout reads "curtailed renewables"

🤖 Generated with [Claude Code](https://claude.com/claude-code)