### PR TITLE
fix(japan): bound area-CSV window at now + fail loudly on partial month fetch

### DIFF
--- a/src/lib/japan-area-csv.ts
+++ b/src/lib/japan-area-csv.ts
@@ -117,6 +117,25 @@ export function parseAreaCsv(decoded: string, cfg: { dateFormat: DateFormat }): 
 }
 
 /**
+ * Keep only the points inside the trailing WINDOW_DAYS up to `now`, sorted
+ * ascending. The lower bound drops months-old rows; the UPPER bound (`<= now`)
+ * drops the future-dated placeholder rows the monthly eria_jukyu CSV pre-fills
+ * for the rest of the calendar month — leaving them in pushes lastUpdated into
+ * the future and dilutes the time-of-day profile with trailing zeros.
+ */
+export function windowedPoints(months: AreaParsed[], now: Date): AreaPoint[] {
+  const cutoffMs = now.getTime() - WINDOW_DAYS * 24 * 3600 * 1000;
+  const nowMs = now.getTime();
+  return months
+    .flatMap((m) => m.points)
+    .filter((p) => {
+      const t = new Date(p.utcTimestamp).getTime();
+      return t >= cutoffMs && t <= nowMs;
+    })
+    .sort((a, b) => a.utcTimestamp.localeCompare(b.utcTimestamp));
+}
+
+/**
  * Merge parsed months, keep the trailing WINDOW_DAYS, and build RegionData
  * with a data-driven fuelShare. Pure (no network) so it is unit-testable.
  * Throws when the window is empty — the loader relies on withFallback serving
@@ -130,11 +149,7 @@ export function mergeWindowBuild(
   sourceNote: string,
   now: Date,
 ): RegionData {
-  const cutoffMs = now.getTime() - WINDOW_DAYS * 24 * 3600 * 1000;
-  const windowed = months
-    .flatMap((m) => m.points)
-    .filter((p) => new Date(p.utcTimestamp).getTime() >= cutoffMs)
-    .sort((a, b) => a.utcTimestamp.localeCompare(b.utcTimestamp));
+  const windowed = windowedPoints(months, now);
 
   if (windowed.length === 0) {
     throw new Error(`${regionId}: no usable curtailment rows in the trailing ${WINDOW_DAYS} days`);
@@ -170,9 +185,33 @@ async function fetchAreaMonth(cfg: JapanAreaConfig, yyyymm: string, timeoutMs = 
 }
 
 /**
+ * Refuse to build from an incomplete fetch. The trailing-30d window spans the
+ * current AND previous calendar month, so if EITHER month CSV fails to fetch
+ * the window silently shrinks to whatever parsed — a too-low magnitude served
+ * as "live". Throwing instead routes withFallback to the complete last-good
+ * snapshot (stampCached marks it cached/degraded by age → amber ring). Keyed
+ * off fetch success, never curtailment magnitude, so a genuine seasonal-zero
+ * month (both CSVs fetched, zero curtailment) still serves honestly as live.
+ */
+export function assertMonthsFetched(
+  fetchFailures: number,
+  expectedMonths: number,
+  regionId: string,
+): void {
+  if (fetchFailures > 0) {
+    throw new Error(
+      `${regionId}: ${fetchFailures}/${expectedMonths} month CSV fetch(es) failed — ` +
+        `refusing to serve a shrunken trailing-${WINDOW_DAYS}d window; ` +
+        `withFallback will serve the last-good snapshot`,
+    );
+  }
+}
+
+/**
  * Fetch the current and previous calendar month, merge, and build the trailing
- * 30-day RegionData. Each month's failure is logged and skipped; throws only if
- * BOTH yield no windowed rows (→ withFallback serves last-good).
+ * 30-day RegionData. A month that fails to fetch makes the window incomplete,
+ * so the whole run throws (→ withFallback serves last-good) rather than serving
+ * a silently-shrunken window. Throws too if the merged window is empty.
  */
 export async function runJapanAreaLoader(cfg: JapanAreaConfig, sourceNote: string): Promise<RegionData> {
   const now = new Date();
@@ -182,14 +221,17 @@ export async function runJapanAreaLoader(cfg: JapanAreaConfig, sourceNote: strin
   const months = [formatYyyyMm(prevD), formatYyyyMm(now)];
 
   const parsed: AreaParsed[] = [];
+  let fetchFailures = 0;
   for (const m of months) {
     try {
       parsed.push(await fetchAreaMonth(cfg, m));
     } catch (err) {
+      fetchFailures++;
       console.warn(`${cfg.regionId} ${m} fetch failed: ${(err as Error).message}`);
     }
     await new Promise((r) => setTimeout(r, 200));
   }
+  assertMonthsFetched(fetchFailures, months.length, cfg.regionId);
   return mergeWindowBuild(parsed, cfg.regionId, sourceNote, now);
 }
 
@@ -205,8 +247,9 @@ export async function runJapanAreaLoader(cfg: JapanAreaConfig, sourceNote: strin
  *
  * Both regionIds must be registered in `src/lib/regions.ts` as
  * `japan-<area>-solar` / `japan-<area>-wind` before this is called.
- * Throws if the windowed point set is empty for EITHER fuel (withFallback
- * then serves the committed last-good snapshot).
+ * Throws if a month CSV fails to fetch (incomplete window) or the windowed
+ * point set is empty — withFallback then serves the committed last-good
+ * snapshot rather than a silently-shrunken window.
  */
 export async function runJapanAreaLoaderSplit(
   cfg: JapanAreaConfig,
@@ -222,20 +265,19 @@ export async function runJapanAreaLoaderSplit(
   const months = [formatYyyyMm(prevD), formatYyyyMm(now)];
 
   const parsed: AreaParsed[] = [];
+  let fetchFailures = 0;
   for (const m of months) {
     try {
       parsed.push(await fetchAreaMonth(cfg, m));
     } catch (err) {
+      fetchFailures++;
       console.warn(`${cfg.regionId} ${m} fetch failed: ${(err as Error).message}`);
     }
     await new Promise((r) => setTimeout(r, 200));
   }
+  assertMonthsFetched(fetchFailures, months.length, cfg.regionId);
 
-  const cutoffMs = now.getTime() - WINDOW_DAYS * 24 * 3600 * 1000;
-  const windowed = parsed
-    .flatMap((m) => m.points)
-    .filter((p) => new Date(p.utcTimestamp).getTime() >= cutoffMs)
-    .sort((a, b) => a.utcTimestamp.localeCompare(b.utcTimestamp));
+  const windowed = windowedPoints(parsed, now);
 
   if (windowed.length === 0) {
     throw new Error(`${cfg.regionId}: no usable curtailment rows in the trailing ${WINDOW_DAYS} days`);

--- a/tests/japan-area-csv.test.ts
+++ b/tests/japan-area-csv.test.ts
@@ -6,7 +6,10 @@ import {
   jstToIsoUtc,
   parseAreaCsv,
   mergeWindowBuild,
+  windowedPoints,
+  assertMonthsFetched,
   type AreaParsed,
+  type AreaPoint,
 } from "../src/lib/japan-area-csv.js";
 
 const fixture = (name: string) =>
@@ -97,5 +100,59 @@ describe("mergeWindowBuild", () => {
   it("throws when no points fall inside the window", () => {
     const old = mk("2026-04-01T03:00:00.000Z", 10, 0);
     expect(() => mergeWindowBuild([old], "japan-test", "note", NOW)).toThrow(/no usable/);
+  });
+
+  it("drops future-dated placeholder rows (window upper bound = now)", () => {
+    // The monthly eria_jukyu CSV is pre-filled for the WHOLE month, so the
+    // current-month file carries future-dated rows (all-zero placeholders).
+    // They must not enter the window: they push lastUpdated into the future
+    // and dilute the time-of-day profile. Cf. Hokuriku 2026-06 (lastUpdated
+    // was 2026-06-30 with data only through the 17th).
+    const NOW2 = new Date("2026-06-17T12:00:00.000Z");
+    const real = mk("2026-06-10T03:00:00.000Z", 200, 0); // in window
+    const future = mk("2026-06-25T03:00:00.000Z", 999, 999); // after NOW2 — placeholder
+    const rd = mergeWindowBuild([real, future], "japan-test", "note", NOW2);
+    // Only the real point contributes to the magnitude.
+    expect(rd.totalTWh).toBeCloseTo((200 * 0.5) / 1_000_000, 12);
+    // lastUpdated reflects the last REAL row, not the future placeholder.
+    expect(rd.lastUpdated).toBe("2026-06-10T03:00:00.000Z");
+  });
+});
+
+describe("windowedPoints", () => {
+  const NOW = new Date("2026-06-17T12:00:00.000Z");
+  const mkP = (iso: string, mw: number): AreaPoint => ({
+    utcTimestamp: iso,
+    mw,
+    intervalHours: 0.5,
+    solarMw: mw,
+    windMw: 0,
+  });
+  const months: AreaParsed[] = [
+    {
+      points: [
+        mkP("2026-06-30T03:00:00.000Z", 3), // future — dropped (upper bound)
+        mkP("2026-06-10T03:00:00.000Z", 2), // in window
+        mkP("2026-05-01T03:00:00.000Z", 1), // > 30d before NOW — dropped (lower bound)
+      ],
+      solarCurtMwSum: 6,
+      windCurtMwSum: 0,
+      sampleCount: 3,
+    },
+  ];
+
+  it("keeps only points within [now-30d, now], sorted ascending", () => {
+    const w = windowedPoints(months, NOW);
+    expect(w.map((p) => p.utcTimestamp)).toEqual(["2026-06-10T03:00:00.000Z"]);
+  });
+});
+
+describe("assertMonthsFetched", () => {
+  it("throws when any expected month CSV failed to fetch (refuse a shrunken window)", () => {
+    expect(() => assertMonthsFetched(1, 2, "japan-test")).toThrow(/shrunk|fetch/i);
+  });
+
+  it("does not throw when every expected month fetched successfully", () => {
+    expect(() => assertMonthsFetched(0, 2, "japan-test")).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Two latent defects in the shared Japanese area-CSV loader (`src/lib/japan-area-csv.ts`), surfaced while investigating an apparent **Hokuriku curtailment drop** (committed baseline 0.0049 TWh/30d vs a re-run of 0.00024). That drop turned out to be **genuine seasonality** — spring curtailment ends ~mid-May; by June Hokuriku curtails ~zero (solar still generates, nothing is curtailed). The loader was fetching/parsing/windowing correctly; these are the real bugs the investigation exposed:

1. **Future-dated placeholder rows were ingested.** The monthly `eria_jukyu` CSV is pre-filled for the whole calendar month, so the trailing-30d window pulled in future rows — pushing `lastUpdated` into the future (Hokuriku showed `2026-06-30` with real data only through the 17th) and diluting the time-of-day profile with trailing zeros. New `windowedPoints()` helper bounds the window at `now` (used by both `mergeWindowBuild` and `runJapanAreaLoaderSplit`).

2. **A single failed month fetch silently shrank the window** and served a too-low value as `live`. `assertMonthsFetched()` now throws when any expected month CSV fails to fetch, so `withFallback` serves the complete last-good snapshot (stamped `cached`/`degraded` by age → amber ring) instead of a half-window. Keyed off **fetch success, never curtailment magnitude**, so genuine seasonal-zero months still serve honestly as `live`.

Covers all monthly-CSV areas (Hokkaido split + the 8 single-region loaders). **No region magnitudes change.**

## Test plan

- [x] 3 new unit tests (`windowedPoints`, `assertMonthsFetched`, `mergeWindowBuild` future-row drop) — TDD red→green
- [x] Full suite: **959 tests pass**
- [x] `npm run typecheck` clean
- [x] `npm run ci:gates` green (magnitude-golden, tier/tally/provenance, docs-drift)
- [x] End-to-end: live Hokuriku loader run confirms `lastUpdated` fixed (`2026-06-30` → `2026-06-17`) and the genuine seasonal value still serves `live`

🤖 Generated with [Claude Code](https://claude.com/claude-code)