### PR TITLE
fix(calc): guard regionGWAtHour against undefined region data (globe crash hotfix #2)

### DIFF
--- a/src/lib/calc.ts
+++ b/src/lib/calc.ts
@@ -18,6 +18,12 @@ export function ehsFromGW(gw: number, effJperTH: number = ASIC_JPER_TH): number 
 }
 
 export function regionGWAtHour(data: RegionData, utcHour: number, mode: DashboardMode = "avg30d"): number {
+  // Defensive: a region whose loader data hasn't resolved (cold-load race on the
+  // slowest FileAttachments) arrives here undefined via aggregateAtHour's
+  // Object.entries(regionData) / the timeline. Reading .latestProfile/.profile
+  // on undefined throws and kills the clock tick → blank globe. Contribute 0
+  // instead; the region rejoins when Observable re-runs with resolved data.
+  if (!data) return 0;
   const profile = mode === "last24h" && Array.isArray(data.latestProfile)
     ? data.latestProfile
     : data.profile;


### PR DESCRIPTION
Second production hotfix. The integrity-check fix (#224) stopped the loading-screen hang, but the same cold-load race then crashed one layer down: `regionGWAtHour` read `.profile` on undefined region data (india-odisha/pakistan unresolved at first render) → TypeError every clock tick → blank globe. Adds an `if (!data) return 0` guard; the region rejoins when its data resolves. Verified: `regionGWAtHour(undefined)`→0, valid data unchanged, calc 10/10, all other consumers already undefined-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)