### PR TITLE
chore(deps): drop unused react-dom + @types/react-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,12 @@
         "d3": "^7.9.0",
         "fast-xml-parser": "^5.7.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1",
         "topojson-client": "^3.1.0"
       },
       "devDependencies": {
         "@types/d3": "^7.4.3",
         "@types/node": "^20.14.0",
         "@types/react": "^18.3.3",
-        "@types/react-dom": "^18.3.0",
         "@types/topojson-client": "^3.1.4",
         "jsdom": "^24.1.0",
         "tsx": "^4.21.0",
@@ -1675,16 +1673,6 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -4333,19 +4321,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -4538,15 +4513,6 @@
       },
       "engines": {
         "node": ">=v12.22.7"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/section-matter": {

--- a/package.json
+++ b/package.json
@@ -40,14 +40,12 @@
     "d3": "^7.9.0",
     "fast-xml-parser": "^5.7.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@types/d3": "^7.4.3",
     "@types/node": "^20.14.0",
     "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
     "@types/topojson-client": "^3.1.4",
     "jsdom": "^24.1.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## What

Removes `react-dom` and `@types/react-dom` from the dependency tree. Pure deletion — 2 files changed, 36 deletions, 0 insertions (prunes `react-dom`, `@types/react-dom`, and react-dom's transitive `scheduler`).

## Why

`react-dom` (4.4 MB) was a **root-only** dependency (`npm ls react-dom` had no other dependents) with **zero import sites** anywhere in `src/` — no `createRoot`, `hydrate`, `ReactDOM`, JSX, or `import "npm:react-dom"`. The browser bundle never included it, since Observable Framework only bundles libraries a page actually imports. So this trims install size and supply-chain surface with no runtime effect.

This is item **#1** from the refactor-opportunities survey (`docs/research/2026-06-17-refactor-opportunities.md`, landing separately) — the zero-risk "lighter" win.

## Scope (deliberately narrow)

`react` itself **stays** — it's pulled by `@vercel/analytics` (deduped). Dropping `react` + `@vercel/analytics` is a separate follow-up (#2 in the survey) because analytics is currently injected via a raw `<script>` tag in `observablehq.config.ts`, and removing the package needs a preview-deploy check that analytics still fires. Keeping this PR to the unambiguous part.

## Verification

- `npm install` resolves cleanly, pruning 3 packages
- `npm ls react-dom` → empty
- `npm ls react` → still resolves via `@vercel/analytics`
- `tsc --noEmit` → clean (confirms `@types/react-dom` removal breaks nothing)
- `npm test` → 955/955 pass
- Full `observable build` is exercised by the `verify` CI check on this PR (it's orthogonal to a React dep, but it's the belt-and-suspenders gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)