### PR TITLE
chore(deps): drop unused @vercel/analytics + react + @types/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,13 @@
       "hasInstallScript": true,
       "dependencies": {
         "@observablehq/framework": "^1.13.0",
-        "@vercel/analytics": "^2.0.1",
         "d3": "^7.9.0",
         "fast-xml-parser": "^5.7.1",
-        "react": "^18.3.1",
         "topojson-client": "^3.1.0"
       },
       "devDependencies": {
         "@types/d3": "^7.4.3",
         "@types/node": "^20.14.0",
-        "@types/react": "^18.3.3",
         "@types/topojson-client": "^3.1.4",
         "jsdom": "^24.1.0",
         "tsx": "^4.21.0",
@@ -1657,24 +1654,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -1700,48 +1679,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
-      }
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -2236,13 +2173,6 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "license": "MIT"
-    },
-    "node_modules/csstype": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3": {
@@ -3621,12 +3551,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "license": "MIT"
-    },
     "node_modules/js-yaml": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
@@ -3735,18 +3659,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -4307,18 +4219,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -36,16 +36,13 @@
   },
   "dependencies": {
     "@observablehq/framework": "^1.13.0",
-    "@vercel/analytics": "^2.0.1",
     "d3": "^7.9.0",
     "fast-xml-parser": "^5.7.1",
-    "react": "^18.3.1",
     "topojson-client": "^3.1.0"
   },
   "devDependencies": {
     "@types/d3": "^7.4.3",
     "@types/node": "^20.14.0",
-    "@types/react": "^18.3.3",
     "@types/topojson-client": "^3.1.4",
     "jsdom": "^24.1.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## What

Completes the React/analytics dependency trim begun in #230 (which dropped `react-dom`). Removes the last three: `@vercel/analytics`, `react`, `@types/react`. 2 files changed, 103 deletions.

## Why

None of these have any import site in `src/`:

- **`@vercel/analytics`** — analytics is injected via a raw `<script src="/_vercel/insights/script.js">` tag in `observablehq.config.ts`, served by Vercel's edge at runtime. It does **not** depend on the npm package (the package only provides `inject()`/`track()`/`<Analytics/>`, none of which are used). Removing it does not affect analytics collection.
- **`react`** — was pulled only by `@vercel/analytics` (deduped) plus a root declaration; nothing in `src` imports it.
- **`@types/react`** — no React/JSX in any `.ts` file.

After this, the dependency list honestly reflects what the project uses (Observable Framework + D3 + topojson + fast-xml-parser).

## Verification

- `npm ls react @vercel/analytics` → empty
- `tsc --noEmit` → clean
- `npm test` → 955/955 pass
- **Reviewer check:** the Vercel preview on this PR should (a) build successfully and (b) still load `/_vercel/insights/script.js` — please confirm analytics fires on the preview before merge.

## Refs

`docs/research/2026-06-17-refactor-opportunities.md` (#2). Depends on #230 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)