### PR TITLE
refactor(pages): extract shared finalizeRegionData pipeline (+ fix embed crash)

### DIFF
--- a/src/embed/globe.md
+++ b/src/embed/globe.md
@@ -162,10 +162,8 @@ document.documentElement.setAttribute("data-theme", "sunfire");
 import { aggregateAtHour, ehsFromGW } from "../lib/calc.js";
 import { REGIONS } from "../lib/regions.js";
 import { isRenewable } from "../lib/fuel.js";
-import { applyUncertainty } from "../lib/uncertainty.js";
 import { splitRegion } from "../lib/split-region.js";
-import { assertCanonicalRegionData } from "../lib/region-data-integrity.js";
-import { maskSolarNight } from "../lib/solar-mask.js";
+import { finalizeRegionData } from "../lib/region-data-finalize.js";
 import { mountGlobe } from "../globe.js";
 
 // Same parallel-fetch pattern as src/index.md. The embed needs the full
@@ -535,29 +533,11 @@ const regionData = {
   ...philippines
 };
 
-assertCanonicalRegionData(regionData, REGIONS);
-
-// Solar-night masking — same physics correction as src/index.md.
-for (const region of REGIONS) {
-  if (region.kind !== "solar") continue;
-  const data = regionData[region.id];
-  if (!data?.profile) continue;
-  data.profile = maskSolarNight(data.profile, region.lon);
-  if (Array.isArray(data.latestProfile)) {
-    data.latestProfile = maskSolarNight(data.latestProfile, region.lon);
-  }
-  data.peakGW = Math.max(...data.profile);
-}
-
-// Defensive uncertainty back-fill — mirrors src/index.md.
-const KIND_TO_PROFILE = { wind: "wind", solar: "solar", mixed: "mixed", hydro: "hydro-seasonal", flare: "flat" };
-for (const region of REGIONS) {
-  const d = regionData[region.id];
-  if (!d) continue;
-  if (d.confidenceTier) continue;
-  const profileKind = region.tier === "static" ? KIND_TO_PROFILE[region.kind] : undefined;
-  regionData[region.id] = applyUncertainty(d, { regionTier: region.tier, profileKind });
-}
+// Finalize the assembled region data — shared with src/index.md. Note: this
+// previously called assertCanonicalRegionData *fatally*, retaining the
+// "stuck loading" crash that #224 fixed for index.md; the shared helper makes
+// it non-fatal here too.
+finalizeRegionData(regionData, REGIONS);
 
 const now = new Date();
 const initialHour = now.getUTCHours() + now.getUTCMinutes() / 60;

--- a/src/index.md
+++ b/src/index.md
@@ -30,10 +30,8 @@ import { mountRegionTooltip } from "./components/region-tooltip.js";
 import { aggregateAtHour, ehsFromGW } from "./lib/calc.js";
 import { REGIONS } from "./lib/regions.js";
 import { FUEL_ORDER, FUEL_LABEL, getFuelColor, fuelShare, isRenewable } from "./lib/fuel.js";
-import { applyUncertainty } from "./lib/uncertainty.js";
 import { splitRegion } from "./lib/split-region.js";
-import { assertCanonicalRegionData } from "./lib/region-data-integrity.js";
-import { maskSolarNight } from "./lib/solar-mask.js";
+import { finalizeRegionData } from "./lib/region-data-finalize.js";
 import { mountGlobe } from "./globe.js";
 
 const HOTSPOT_LIST_LIMIT = 50;
@@ -617,66 +615,11 @@ const regionData = {
   ...philippines
 };
 
-// Warn loudly (console) if any canonical region is missing or has a malformed
-// value (e.g. multi-region loader's whole Record wired into a single key —
-// Belgium-shape bug class). This MUST NOT throw: it runs synchronously right
-// after the regionData literal, and on a cold load the slowest FileAttachment
-// loaders can still be resolving, so a hard throw here halts the whole
-// dashboard init (stuck "Loading dashboard data") on a transient load race.
-// Surface the issue in the console for monitoring, but always render.
-try {
-  assertCanonicalRegionData(regionData, REGIONS);
-} catch (err) {
-  console.error("[region-data-integrity]", (err && err.message) || err);
-}
-
-// Solar-physics correction: zero out hours where the sun is below the horizon
-// for any region of kind:solar. Several grid-operator feeds (CAISO, PJM, MISO,
-// SPP, NYISO, ERCOT, BPA) report a non-zero "solar" floor at local night —
-// most likely battery discharge mis-categorised as solar in the EIA fuel-type
-// breakdown. Whatever the cause, solar curtailment outside daylight is
-// physically impossible, so the dashboard refuses to show it.
-for (const region of REGIONS) {
-  if (region.kind !== "solar") continue;
-  const data = regionData[region.id];
-  if (!data?.profile) continue;
-  data.profile = maskSolarNight(data.profile, region.lon);
-  if (Array.isArray(data.latestProfile)) {
-    data.latestProfile = maskSolarNight(data.latestProfile, region.lon);
-  }
-  data.peakGW = Math.max(...data.profile);
-}
-
-// S2 uncertainty: defensive fallback. Every loader is now responsible for
-// setting confidenceTier + uncertaintyLow/HighGW upstream — typical-shape
-// builders in `src/lib/typical-profiles.ts`, the statics builder in
-// `src/data/statics.json.ts`, and the cache-boundary `enrichWithTier` in
-// `src/lib/resilient.ts` between them cover live, static-modelled, and
-// flare regions. This loop is a defensive shim for any region that slips
-// through (e.g. a future region added to regions.ts without a loader call
-// to applyUncertainty).
-//
-// We derive profileKind from regions.ts kind so the fallback assigns the
-// correct tier rather than silently routing every static through T2:
-//   wind/solar/mixed → T3-modelled
-//   hydro            → T3-modelled (hydro-seasonal fallback)
-//   flare            → T2-annual-calibrated (flat 24/7)
-//   live regions     → T1-live-TSO (no profileKind)
-const KIND_TO_PROFILE = {
-  wind: "wind",
-  solar: "solar",
-  mixed: "mixed",
-  hydro: "hydro-seasonal",
-  flare: "flat"
-};
-for (const region of REGIONS) {
-  const d = regionData[region.id];
-  if (!d) continue;
-  if (d.confidenceTier) continue; // preserve tier already set by loader
-  const profileKind = region.tier === "static" ? KIND_TO_PROFILE[region.kind] : undefined;
-  console.warn(`[uncertainty] late-binding tier for ${region.id} (kind=${region.kind}); loader should set this upstream`);
-  regionData[region.id] = applyUncertainty(d, { regionTier: region.tier, profileKind });
-}
+// Finalize the assembled region data — non-fatal integrity check (#224),
+// solar-night masking, and defensive uncertainty back-fill. Extracted to a
+// shared helper so this page and src/embed/globe.md cannot drift apart
+// (src/lib/region-data-finalize.ts).
+finalizeRegionData(regionData, REGIONS);
 
 // Populate the region-count span inside the lead copy without clobbering
 // the surrounding HTML (the ${FUEL_ORDER.map} earlier baked it in at render).

--- a/src/lib/region-data-finalize.ts
+++ b/src/lib/region-data-finalize.ts
@@ -1,0 +1,66 @@
+import type { Region, RegionData } from "./types.js";
+import { assertCanonicalRegionData } from "./region-data-integrity.js";
+import { maskSolarNight } from "./solar-mask.js";
+import { applyUncertainty } from "./uncertainty.js";
+
+/**
+ * Shared region-data finalize pipeline, factored out of the duplicated tails of
+ * `src/index.md` and `src/embed/globe.md`. The two copies had already drifted:
+ * embed still called the integrity check *fatally* — the exact "stuck loading"
+ * crash that #224 made non-fatal for index.md. Centralising here fixes that and
+ * keeps the two pages from diverging again.
+ *
+ * Three passes over the assembled `regionData` (mutated in place, then returned):
+ *
+ *   1. Canonical-shape integrity check — **non-fatal** (logs, never throws).
+ *      Loaders can still be resolving at page init, so a hard throw would halt
+ *      the whole dashboard. Surface for monitoring, but always render. (#224.)
+ *   2. Solar-night masking — zero out sub-horizon hours for `kind: "solar"`
+ *      regions. Several grid feeds (CAISO, PJM, MISO, SPP, NYISO, ERCOT, BPA)
+ *      report a non-zero "solar" floor at local night; curtailment outside
+ *      daylight is physically impossible.
+ *   3. Defensive uncertainty back-fill — for any region a loader left without a
+ *      `confidenceTier`.
+ *
+ * Note: the old inline copies computed `profileKind` via
+ * `region.tier === "static" ? … : undefined`, but `"static"` was retired as a
+ * tier in PR #88 (so the branch was unreachable) and `applyUncertainty` derives
+ * the tier solely from `regionTier` (`profileKind` is unused). The dead branch
+ * is dropped here with no behavioural change.
+ */
+export function finalizeRegionData(
+  regionData: Record<string, RegionData>,
+  regions: readonly Region[],
+): Record<string, RegionData> {
+  // 1. Integrity check — non-fatal (see #224).
+  try {
+    assertCanonicalRegionData(regionData, regions);
+  } catch (err) {
+    console.error("[region-data-integrity]", (err && (err as Error).message) || err);
+  }
+
+  // 2. Solar-physics correction.
+  for (const region of regions) {
+    if (region.kind !== "solar") continue;
+    const data = regionData[region.id];
+    if (!data?.profile) continue;
+    data.profile = maskSolarNight(data.profile, region.lon);
+    if (Array.isArray(data.latestProfile)) {
+      data.latestProfile = maskSolarNight(data.latestProfile, region.lon);
+    }
+    data.peakGW = Math.max(...data.profile);
+  }
+
+  // 3. Defensive uncertainty back-fill.
+  for (const region of regions) {
+    const d = regionData[region.id];
+    if (!d) continue;
+    if (d.confidenceTier) continue; // preserve tier already set by loader
+    console.warn(
+      `[uncertainty] late-binding tier for ${region.id} (kind=${region.kind}); loader should set this upstream`,
+    );
+    regionData[region.id] = applyUncertainty(d, { regionTier: region.tier });
+  }
+
+  return regionData;
+}

--- a/tests/region-data-finalize.test.ts
+++ b/tests/region-data-finalize.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { finalizeRegionData } from "../src/lib/region-data-finalize";
+import type { Region, RegionData } from "../src/lib/types";
+
+// Minimal valid fixtures — only the fields the finalize pipeline touches.
+function mkRegion(over: Partial<Region> & Pick<Region, "id" | "kind" | "tier">): Region {
+  return {
+    name: over.id,
+    country: "XXX",
+    lat: 0,
+    lon: 0,
+    source: "test",
+    sourceUrl: "https://example.test",
+    ...over,
+  };
+}
+
+function mkData(over: Partial<RegionData> & Pick<RegionData, "regionId">): RegionData {
+  return {
+    profile: new Array(24).fill(1),
+    latestProfile: null,
+    totalTWh: 1,
+    peakGW: 1,
+    lastUpdated: "2026-01-01T00:00:00Z",
+    lastSuccessAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("finalizeRegionData", () => {
+  beforeEach(() => {
+    // The defensive uncertainty back-fill warns for any region without a
+    // confidenceTier; silence it so test output stays pristine.
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not throw when regionData does not match REGIONS — it logs instead (propagates the #224 non-fatal integrity check)", () => {
+    const regions = [mkRegion({ id: "a", kind: "wind", tier: "live" })];
+    const regionData: Record<string, RegionData> = {}; // missing "a"
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => finalizeRegionData(regionData, regions)).not.toThrow();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("masks solar regions at night but leaves non-solar profiles untouched", () => {
+    const regions = [
+      mkRegion({ id: "sun", kind: "solar", tier: "estimated", lon: 0 }),
+      mkRegion({ id: "wnd", kind: "wind", tier: "estimated", lon: 0 }),
+    ];
+    const regionData: Record<string, RegionData> = {
+      sun: mkData({ regionId: "sun", profile: new Array(24).fill(2), peakGW: 2 }),
+      wnd: mkData({ regionId: "wnd", profile: new Array(24).fill(2), peakGW: 2 }),
+    };
+
+    finalizeRegionData(regionData, regions);
+
+    // Solar: some night hours zeroed; profile no longer all-2.
+    expect(regionData.sun.profile.some((v) => v === 0)).toBe(true);
+    expect(regionData.sun.profile).not.toEqual(new Array(24).fill(2));
+    expect(regionData.sun.peakGW).toBe(Math.max(...regionData.sun.profile));
+    // Wind: untouched by solar masking.
+    expect(regionData.wnd.profile).toEqual(new Array(24).fill(2));
+  });
+
+  it("back-fills a missing confidenceTier from regionTier", () => {
+    const regions = [mkRegion({ id: "a", kind: "wind", tier: "estimated" })];
+    const regionData: Record<string, RegionData> = { a: mkData({ regionId: "a" }) };
+
+    finalizeRegionData(regionData, regions);
+
+    expect(regionData.a.confidenceTier).toBe("T3-modelled");
+  });
+
+  it("preserves a confidenceTier already set by the loader", () => {
+    const regions = [mkRegion({ id: "a", kind: "wind", tier: "live" })];
+    const regionData: Record<string, RegionData> = {
+      a: mkData({ regionId: "a", confidenceTier: "T1a-live-tso" }),
+    };
+
+    finalizeRegionData(regionData, regions);
+
+    expect(regionData.a.confidenceTier).toBe("T1a-live-tso");
+  });
+});


### PR DESCRIPTION
## What

Extracts the duplicated region-data *finalize* tail from `src/index.md` and `src/embed/globe.md` into a unit-tested helper, `src/lib/region-data-finalize.ts`, called by both pages.

The pipeline is three passes over the assembled `regionData`: non-fatal canonical-shape integrity check → solar-night masking → defensive uncertainty back-fill.

## Why

1. **Dedup** — both pages carried byte-for-byte copies of this logic; the survey already noted the two pages have drifted (index lists 136 loaders, embed 122). One source of truth stops further drift.
2. **Latent-crash fix** — `embed/globe.md` still called `assertCanonicalRegionData` **fatally**, i.e. it retained the exact "stuck loading" crash that [#224](https://github.com/honeybeesquad/every-last-joule-dashboard/pull/224) made non-fatal for `index.md`. The shared helper applies the non-fatal version everywhere.
3. **Dead-code removal (behaviour-preserving)** — the inline `region.tier === "static" ? KIND_TO_PROFILE[...] : undefined` branch was unreachable: `"static"` was retired as a tier in #88, and `applyUncertainty` derives the tier solely from `regionTier` (`profileKind` is unused). Dropped, with the rationale documented in the helper.

## Scope note (#3 from the refactor survey, revised)

The survey's "loop `FileAttachment` over a manifest" idea is **infeasible** — Observable Framework requires `FileAttachment` to take a static string literal (confirmed: every call in the repo is a literal). The 136 loader-wiring lines can't be collapsed into a loop. This is the *feasible, higher-value* dedup that was actually available.

## Verification

- New `tests/region-data-finalize.test.ts` — TDD, 4 cases (non-fatal assert, solar masking applied to solar/skipped for non-solar, uncertainty back-fill from `regionTier`, preserves a loader-set `confidenceTier`).
- `tsc --noEmit` clean · `npm test` **959/959** pass.
- Behaviour-preserving except the intended embed non-fatal fix.
- **Page integration is exercised by this PR's Vercel preview build** — please confirm the dashboard + embed globe render before merge (a local `observable build` fires 132 live loader requests for no extra signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)