### PR TITLE
refactor(globe): extract pure helpers (wrapLongitude, easeOutCubic) to a tested lib

### DIFF
--- a/src/globe.js
+++ b/src/globe.js
@@ -5,6 +5,7 @@ import { getRegionFuelColor } from "./lib/fuel.js";
 import { readGlobeTokens, isLinearGradientToken } from "./lib/theme-tokens.js";
 import { buildPillarUnits } from "./lib/pillar-layout.js";
 import { qualityBucket, qualityOpacity, dotStyleFor } from "./lib/region-quality.js";
+import { wrapLongitude, easeOutCubic } from "./lib/globe-geo.js";
 
 // Locally-vendored world atlas: previously fetched from unpkg.com, which
 // added a third-party DNS + TLS handshake (~200–400ms on cellular) to
@@ -116,10 +117,6 @@ export async function mountGlobe(canvas, initial) {
   // region and animate scale 0 → 1 over BIRTH_MS.
   const BIRTH_MS = 350;
   const pillarBirthTimes = new Map(); // repId → DOMHighResTimeStamp
-
-  function easeOutCubic(t) {
-    return 1 - Math.pow(1 - t, 3);
-  }
 
   /**
    * Hit-test: given client coords, return the closest pillar group within
@@ -740,8 +737,4 @@ export async function mountGlobe(canvas, initial) {
       canvas.removeEventListener("wheel", onWheel);
     }
   };
-}
-
-function wrapLongitude(value) {
-  return ((value + 180) % 360 + 360) % 360 - 180;
 }

--- a/src/lib/globe-geo.ts
+++ b/src/lib/globe-geo.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure geometry/easing helpers for the canvas globe, lifted out of
+ * `src/globe.js` so they can be unit-tested in isolation (globe.js itself is a
+ * single large closure with no test coverage). These are byte-for-byte the
+ * same implementations as the inline originals — extracting them changes no
+ * behaviour; it just makes the math testable and reusable.
+ *
+ * First slice of the globe-split plan (docs/research/2026-06-17-globe-split-plan.md, Step 1).
+ */
+
+/** Normalise a longitude into the half-open range (-180, 180]. */
+export function wrapLongitude(value: number): number {
+  return ((value + 180) % 360 + 360) % 360 - 180;
+}
+
+/** Cubic ease-out: fast at the start, decelerating to 0 velocity at t=1. */
+export function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}

--- a/tests/globe-geo.test.ts
+++ b/tests/globe-geo.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { wrapLongitude, easeOutCubic } from "../src/lib/globe-geo";
+
+describe("wrapLongitude", () => {
+  it("leaves in-range longitudes unchanged", () => {
+    expect(wrapLongitude(0)).toBe(0);
+    expect(wrapLongitude(45)).toBe(45);
+    expect(wrapLongitude(-90)).toBe(-90);
+  });
+  it("wraps past +180 into the negative half", () => {
+    expect(wrapLongitude(190)).toBe(-170);
+    expect(wrapLongitude(200)).toBe(-160);
+  });
+  it("wraps past -180 into the positive half", () => {
+    expect(wrapLongitude(-190)).toBe(170);
+  });
+  it("maps the +180 boundary to -180", () => {
+    expect(wrapLongitude(180)).toBe(-180);
+  });
+  it("normalizes full turns", () => {
+    expect(wrapLongitude(360)).toBe(0);
+    expect(wrapLongitude(370)).toBe(10);
+  });
+});
+
+describe("easeOutCubic", () => {
+  it("is pinned at the endpoints", () => {
+    expect(easeOutCubic(0)).toBe(0);
+    expect(easeOutCubic(1)).toBe(1);
+  });
+  it("eases out — most of the travel happens early", () => {
+    expect(easeOutCubic(0.5)).toBe(0.875);
+  });
+});


### PR DESCRIPTION
## What

First (lowest-risk) slice of the globe-split plan: lifts the two pure functions `wrapLongitude` and `easeOutCubic` out of the 747-line, untested `src/globe.js` closure into a new `src/lib/globe-geo.ts`, with unit tests.

## Why

`globe.js` has **no test coverage** and is fragile (two crash hotfixes this week). The geometry/easing math is exactly the kind of thing that silently regresses. Extracting the genuinely-pure helpers lets them be unit-tested directly, at zero behavioural risk — the implementations are byte-identical and the 5 call sites are unchanged.

This is **Step 1 of 6** in `docs/research/2026-06-17-globe-split-plan.md`. Steps 5–6 (the draw-layer / pillar split) are higher-risk and gated behind a headless render harness (Step 4) — a separate, human-reviewed session.

## Verification

- TDD: `tests/globe-geo.test.ts` — 7 cases (longitude wrap incl. ±180 boundaries and full turns; cubic ease-out endpoints + midpoint).
- `tsc --noEmit` clean · `npm test` **962/962** pass.
- No behaviour change; the globe render path is exercised by this PR's Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)