### PR TITLE
fix(ontario): stop loader corrupting its JSON (production down)

### DIFF
--- a/src/data/ontario-per-plant.json.ts
+++ b/src/data/ontario-per-plant.json.ts
@@ -374,7 +374,9 @@ const run = async (): Promise<Record<string, PerPlantRegionData>> => {
     );
   }
 
-  console.log(
+  // Diagnostics MUST go to stderr: this loader's stdout IS the data file, so
+  // a stray console.log() corrupts the emitted JSON and breaks the dashboard.
+  console.warn(
     `ieso-per-plant: ${Object.keys(out).length} plants above threshold ` +
     `from ${plantMap.size} total, ${totalPoints} curtailment points`,
   );


### PR DESCRIPTION
## Production is down — root cause

`everylastjoule.com` renders only the loading screen and never shows the dashboard. Browser console:

\`\`\`
SyntaxError: Unexpected token 'i', "ieso-per-p"... is not valid JSON
\`\`\`

The deployed \`data/ontario-per-plant.json\` begins with a log line instead of JSON:

\`\`\`
ieso-per-plant: 52 plants above threshold from 52 total, 90659 curtailment points
{"ieso-adelaide-wind":{...}}
\`\`\`

[src/data/ontario-per-plant.json.ts](src/data/ontario-per-plant.json.ts) emitted that summary via \`console.log\` → **stdout**. An Observable data loader's stdout **is** the emitted data file, so the line was prepended to the JSON. The dashboard awaits all region files in one \`Promise.all\`; \`FileAttachment(...).json()\` throws on this file → the whole load rejects → site frozen (it was the **only** corrupt file of 137).

## Fix
\`console.log\` → \`console.warn\` (stderr), matching [aemo-per-plant.json.ts](src/data/aemo-per-plant.json.ts). One line.

## Verification
- Re-ran the loader: stdout is now **valid JSON** (63,304 B, starts with \`{\`); the summary now prints to **stderr**.
- Scanned all 137 prod data files: \`ontario-per-plant\` was the only invalid one.

Prod recovers on merge + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)