### PR TITLE
docs(claude): add "Writing data PRs" rules to operating guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,20 @@ This rule was added 2026-04-28 after a session burnt tokens drafting a Phase A p
 
 Any session that ships work to `main`, or notices that STATUS is wrong, must update `STATUS.md` in the same commit. Stale STATUS is worse than no STATUS — it actively misleads.
 
+## Writing data PRs (tiers, regions, honesty)
+
+Multiple AI-authored data PRs (e.g. #267) shipped descriptions claiming tier upgrades and new regions the diff didn't contain. Root cause every time: **the PR was written from the plan, not the diff.** Follow these rules for any PR that touches `regions.ts` or `src/data/*`:
+
+1. **Describe the diff, not the intent.** Before opening or updating a PR, run `git diff --stat origin/main...HEAD` and write the summary from that output. Every file and every claim must map to a changed line. Unfinished ambitions go under a "Follow-ups" heading — never in the summary as if done. The PR title becomes the squash-commit subject on `main`, so an overstated title is a permanent false record in the history this file tells you to trust.
+
+2. **A tier is the `tier:` field in `src/lib/regions.ts` — prose is not a tier change.** Editing a `source:` string to say "anchored" or "T2" changes nothing the dashboard or dataset sees. A real upgrade needs, in one commit: the `tier:` field **+** `scripts/ci/golden/tier-counts.json` **+** `STATUS.md`. Litmus test: if `npm run tally:tiers` is unchanged (or `ci:tally-golden` passes without you touching the golden file), no tier moved — strip every "upgrade / anchored / T2 / T3→T2" word from the PR.
+
+3. **Honesty — the repo's whole point.** The label must match the `tier:` field: never call `estimated`/synthetic data anchored, measured, or live (in headers, comments, or `source:` strings). Never delete an honesty caveat (e.g. "the X% rate was an invented placeholder") unless you added the data that makes it false. A "live probe" that always falls through to fallback is decoration, not an integration — don't describe it as live. Changing a headline anchor (e.g. 0.5 → 2.1 TWh/yr) needs a citation in the same edit and an explicit call-out, because it moves the dataset's totals.
+
+4. **Keep your own numbers consistent** across the `regions.ts` `source:` string, the loader constant, and the `SOURCE_NOTE`. Grep your own figures across the diff before pushing.
+
+5. **Run the gates locally before requesting review:** `npm run typecheck && npm test && npm run ci:tier-coherence && npm run ci:tally-golden && npm run ci:docs-drift`. Green proves structure, not prose — honesty (rule 3) is on you.
+
 ## Things this repo expects you to know
 
 - **Active branch:** `main` (production branch). Open launch work as PRs into `main`; do not push directly to it.


### PR DESCRIPTION
## Summary

Adds a **"Writing data PRs (tiers, regions, honesty)"** section to `CLAUDE.md` so the rules surfaced in the #267 review land in every future AI session automatically (CLAUDE.md is loaded into context each session; a PR comment is not).

Root cause both #267 rounds shared: **the PR was written from the plan, not the diff** — claiming tier upgrades and new regions the diff didn't contain. The new section codifies five rules:

1. **Describe the diff, not the intent** — write the summary from `git diff --stat origin/main...HEAD`; the title becomes the squash-commit subject on `main`.
2. **A tier is the `tier:` field, not prose** — real upgrade = tier field + `tier-counts.json` + `STATUS.md`; if `tally:tiers` is unchanged, strip all "upgrade/anchored/T2" wording.
3. **Honesty** — label matches tier; don't delete caveats; probe-and-discard isn't "live"; anchor changes need a citation.
4. **Keep numbers consistent** across `regions.ts` / loader const / `SOURCE_NOTE`.
5. **Run the gates locally** before requesting review.

### Files changed
- `CLAUDE.md` — +14 lines, one new section (docs only)

No code or data touched; no tier buckets affected.