### PR TITLE
feat(data): two-sided — expose gross renewable generation alongside curtailment

### DIFF
--- a/dataset/schema/region-snapshot.schema.json
+++ b/dataset/schema/region-snapshot.schema.json
@@ -105,6 +105,18 @@
         "T4-structural-gap"
       ],
       "description": "Deterministic source-quality classification. Per B4 Option B (locked 2026-04-25, see docs/proposals/b4-option-b-decision.md), T1 is subdivided into T1a (own-jurisdiction calibration rate; \u00b115%), T1b (domestic-stat-agency rate or modelled-share split; empirical \u00b150%), and T1c (neighbour-extrapolated rate; empirical \u00b135.5%). T2 = static anchored to a published annual (Ember, IRENA, GGFR, TSO annual; \u00b120%). T3 = static annual + typical-shape profile (solar/wind/hydro-seasonal/mixed/overnight; \u00b140%). T4 is reserved in the enum for symmetry but is never emitted \u2014 structural-gap regions do not appear in the dataset at all. The pre-2026-04-25 single label \"T1-live-TSO\" is retained for backward compatibility on legacy snapshots; new emissions use T1a/T1b/T1c. Derived deterministically by src/lib/uncertainty.ts::deriveTier; see docs/methodology/uncertainty.md."
+    },
+    "generationProfile": {
+      "type": "array",
+      "description": "30-day trailing average gross renewable generation in GW, one value per UTC hour (index 0 = 00:00\u201301:00 UTC). Companion to profile (curtailment). Populated progressively by loaders that expose two-sided data (generation + curtailment); absence means the loader has not yet exposed generation as a first-class field.",
+      "minItems": 24,
+      "maxItems": 24,
+      "items": {"type": "number", "minimum": 0}
+    },
+    "generationTotalTWh": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Trailing-30-day total gross renewable generation in TWh. Companion to totalTWh (curtailment). generationTotalTWh >= totalTWh must hold (cannot curtail more than was generated)."
     }
   },
   "additionalProperties": false

--- a/src/lib/eia-iso.ts
+++ b/src/lib/eia-iso.ts
@@ -102,6 +102,14 @@ function toPoints(raw: EIAResponse, rate: number): CurtailmentPoint[] {
   }));
 }
 
+/** Extract raw generation points (pre-rate) from an EIA response. */
+function toGenPoints(raw: EIAResponse): CurtailmentPoint[] {
+  return raw.response.data.map((r) => ({
+    utcTimestamp: `${r.period}:00:00Z`,
+    mw: Math.max(0, Number(r.value)),
+  }));
+}
+
 export function parseEiaIsoRegionPerFuel(
   config: EiaIsoConfig,
   windRaw: EIAResponse,
@@ -125,6 +133,10 @@ export function parseEiaIsoRegionPerFuel(
     ? { wind: windTotalMw / denom, solar: solarTotalMw / denom }
     : { wind: 1, solar: 0 };
 
+  // Raw generation points (pre-rate) for the two-sided output.
+  const windGenPoints = toGenPoints(windRaw);
+  const solarGenPoints = toGenPoints(solarRaw ?? { response: { total: 0, data: [] } });
+
   const wind: RegionData = {
     regionId: `${config.regionId}-wind`,
     profile: timeOfDayAverageGW(windPoints),
@@ -134,6 +146,8 @@ export function parseEiaIsoRegionPerFuel(
     lastUpdated: windLast,
     lastSuccessAt: windLast,
     sourceNote: `EIA ${config.respondent} wind × ${(config.windRate * 100).toFixed(1)}% calibrated curtailment (observed 30d share: wind ${(fuelShare.wind * 100).toFixed(0)}%)`,
+    generationProfile: timeOfDayAverageGW(windGenPoints),
+    generationTotalTWh: totalTWh30d(windGenPoints),
   };
 
   const solar: RegionData = {
@@ -145,6 +159,8 @@ export function parseEiaIsoRegionPerFuel(
     lastUpdated: solarLast,
     lastSuccessAt: solarLast,
     sourceNote: `EIA ${config.respondent} solar × ${(config.solarRate * 100).toFixed(1)}% calibrated curtailment (observed 30d share: solar ${(fuelShare.solar * 100).toFixed(0)}%)`,
+    generationProfile: timeOfDayAverageGW(solarGenPoints),
+    generationTotalTWh: totalTWh30d(solarGenPoints),
   };
 
   return { wind, solar };
@@ -173,6 +189,11 @@ export function parseEiaIsoRegion(
     : { wind: 1, solar: 0 };
   const lastPeriod = combined.at(-1)?.utcTimestamp ?? new Date().toISOString();
 
+  // Raw generation points (pre-rate) merged for the two-sided output.
+  const windGenPoints = toGenPoints(windRaw);
+  const solarGenPoints = toGenPoints({ response: { total: solarRaw?.response?.total ?? 0, data: solarRaw?.response?.data ?? [] } });
+  const combinedGen = mergeSum(windGenPoints, solarGenPoints);
+
   return {
     regionId: config.regionId,
     profile: timeOfDayAverageGW(combined),
@@ -183,6 +204,8 @@ export function parseEiaIsoRegion(
     lastSuccessAt: lastPeriod,
     sourceNote: `EIA ${config.respondent} hourly wind × ${(config.windRate * 100).toFixed(1)}% + solar × ${(config.solarRate * 100).toFixed(1)}% calibrated curtailment (observed 30d split: wind ${(fuelShare.wind * 100).toFixed(0)}% / solar ${(fuelShare.solar * 100).toFixed(0)}%)`,
     fuelShare,
+    generationProfile: timeOfDayAverageGW(combinedGen),
+    generationTotalTWh: totalTWh30d(combinedGen),
   };
 }
 

--- a/src/lib/entsoe.ts
+++ b/src/lib/entsoe.ts
@@ -116,6 +116,8 @@ export function buildZoneData(
     lastUpdated: rawPoints.at(-1)?.utcTimestamp ?? new Date().toISOString(),
     lastSuccessAt: rawPoints.at(-1)?.utcTimestamp ?? new Date().toISOString(),
     sourceNote,
+    generationProfile: timeOfDayAverageGW(rawPoints),
+    generationTotalTWh: totalTWh30d(rawPoints),
   };
 
   if (fuelShare && Object.keys(fuelShare).length > 0) data.fuelShare = fuelShare;
@@ -210,6 +212,26 @@ export async function fetchEntsoeZone(zone: EntsoeZoneSpec): Promise<RegionData>
     );
   }
 
+  // Accumulate raw generation points (pre-rate) across all technologies
+  // for the two-sided output. Each series contributes its raw A75 MW values.
+  const genSummed = new Map<string, { mw: number; intervalHours: number | undefined }>();
+  for (const { technology, points: techPoints } of series) {
+    for (const point of techPoints) {
+      const existing = genSummed.get(point.utcTimestamp);
+      genSummed.set(point.utcTimestamp, {
+        mw: (existing?.mw ?? 0) + Math.max(0, point.mw),
+        intervalHours: existing?.intervalHours ?? point.intervalHours,
+      });
+    }
+  }
+  const genPoints = Array.from(genSummed.entries())
+    .map(([utcTimestamp, point]) => ({
+      utcTimestamp,
+      mw: point.mw,
+      intervalHours: point.intervalHours,
+    }))
+    .sort((a, b) => a.utcTimestamp.localeCompare(b.utcTimestamp));
+
   const denom = Object.values(fuelTotals).reduce((sum, value) => sum + (value ?? 0), 0);
   const fuelShare = denom > 0
     ? Object.fromEntries(
@@ -233,5 +255,7 @@ export async function fetchEntsoeZone(zone: EntsoeZoneSpec): Promise<RegionData>
     lastSuccessAt: lastUpdated ?? new Date().toISOString(),
     sourceNote,
     ...(fuelShare ? { fuelShare } : {}),
+    generationProfile: timeOfDayAverageGW(genPoints),
+    generationTotalTWh: totalTWh30d(genPoints),
   };
 }

--- a/tests/two-sided-generation.test.ts
+++ b/tests/two-sided-generation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Two-sided generation tests.
+ *
+ * Verifies that eia-iso and entsoe build paths emit `generationProfile`
+ * (length 24) and `generationTotalTWh`, and that the fundamental invariant
+ * generationTotalTWh >= totalTWh holds (cannot curtail more than you generate).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseEiaIsoRegionPerFuel,
+  parseEiaIsoRegion,
+  type EIAResponse,
+  type EiaIsoConfig,
+} from "../src/lib/eia-iso";
+import { buildZoneData } from "../src/lib/entsoe";
+import type { CurtailmentPoint } from "../src/lib/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal EIAResponse with `n` hourly rows at a fixed MW value. */
+function makeEiaResponse(mw: number, n = 30 * 24): EIAResponse {
+  const data: EIAResponse["response"]["data"] = [];
+  const base = new Date("2026-05-01T00:00:00Z");
+  for (let i = 0; i < n; i++) {
+    const dt = new Date(base.getTime() + i * 3_600_000);
+    // EIA period format: "2026-05-01T00" (no seconds/Z)
+    const period = dt.toISOString().slice(0, 13);
+    data.push({ period, respondent: "TEST", fueltype: "WND", value: String(mw) });
+  }
+  return { response: { total: n, data } };
+}
+
+/** Build CurtailmentPoint[] with constant MW at every UTC hour over `days`. */
+function makeRawPoints(mw: number, days = 30): CurtailmentPoint[] {
+  const points: CurtailmentPoint[] = [];
+  const base = new Date("2026-05-01T00:00:00Z");
+  for (let i = 0; i < days * 24; i++) {
+    const dt = new Date(base.getTime() + i * 3_600_000);
+    points.push({ utcTimestamp: dt.toISOString(), mw, intervalHours: 1 });
+  }
+  return points;
+}
+
+const BASE_CONFIG: EiaIsoConfig = {
+  regionId: "test-iso",
+  respondent: "TEST",
+  displayName: "Test ISO",
+  windRate: 0.1,   // 10% curtailment
+  solarRate: 0.05, // 5% curtailment
+};
+
+// ---------------------------------------------------------------------------
+// eia-iso: parseEiaIsoRegionPerFuel
+// ---------------------------------------------------------------------------
+
+describe("parseEiaIsoRegionPerFuel — two-sided generation", () => {
+  const windRaw = makeEiaResponse(1000); // 1000 MW generation
+  const solarRaw = makeEiaResponse(500); // 500 MW generation
+
+  const { wind, solar } = parseEiaIsoRegionPerFuel(BASE_CONFIG, windRaw, solarRaw);
+
+  it("wind: emits generationProfile of length 24", () => {
+    expect(wind.generationProfile).toBeDefined();
+    expect(wind.generationProfile!.length).toBe(24);
+  });
+
+  it("wind: generationProfile values are all non-negative", () => {
+    expect(wind.generationProfile!.every((v) => v >= 0)).toBe(true);
+  });
+
+  it("wind: emits generationTotalTWh", () => {
+    expect(wind.generationTotalTWh).toBeDefined();
+    expect(wind.generationTotalTWh).toBeGreaterThanOrEqual(0);
+  });
+
+  it("wind: generationTotalTWh >= totalTWh (generation >= curtailment)", () => {
+    expect(wind.generationTotalTWh!).toBeGreaterThanOrEqual(wind.totalTWh);
+  });
+
+  it("wind: generationTotalTWh is approximately totalTWh / windRate", () => {
+    // curtailment = generation * rate  →  generation = curtailment / rate
+    expect(wind.generationTotalTWh!).toBeCloseTo(wind.totalTWh / BASE_CONFIG.windRate, 5);
+  });
+
+  it("solar: emits generationProfile of length 24", () => {
+    expect(solar.generationProfile).toBeDefined();
+    expect(solar.generationProfile!.length).toBe(24);
+  });
+
+  it("solar: generationTotalTWh >= totalTWh", () => {
+    expect(solar.generationTotalTWh!).toBeGreaterThanOrEqual(solar.totalTWh);
+  });
+
+  it("solar: generationTotalTWh is approximately totalTWh / solarRate", () => {
+    expect(solar.generationTotalTWh!).toBeCloseTo(solar.totalTWh / BASE_CONFIG.solarRate, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// eia-iso: parseEiaIsoRegion (aggregate / single-region path)
+// ---------------------------------------------------------------------------
+
+describe("parseEiaIsoRegion — two-sided generation", () => {
+  const windRaw = makeEiaResponse(2000);
+  const solarRaw = makeEiaResponse(800);
+
+  const region = parseEiaIsoRegion(BASE_CONFIG, windRaw, solarRaw);
+
+  it("emits generationProfile of length 24", () => {
+    expect(region.generationProfile).toBeDefined();
+    expect(region.generationProfile!.length).toBe(24);
+  });
+
+  it("generationProfile values are all non-negative", () => {
+    expect(region.generationProfile!.every((v) => v >= 0)).toBe(true);
+  });
+
+  it("emits generationTotalTWh", () => {
+    expect(region.generationTotalTWh).toBeDefined();
+    expect(typeof region.generationTotalTWh).toBe("number");
+  });
+
+  it("generationTotalTWh >= totalTWh", () => {
+    expect(region.generationTotalTWh!).toBeGreaterThanOrEqual(region.totalTWh);
+  });
+
+  it("does not mutate totalTWh (curtailment unchanged)", () => {
+    // Reproduce the same curtailment independently and confirm region.totalTWh matches.
+    const windOnly = parseEiaIsoRegion({ ...BASE_CONFIG, solarRate: 0 }, windRaw, undefined);
+    // With solarRate=0 solar contributes 0 curtailment, so totalTWh ≈ wind curtailment.
+    // Full region should have higher totalTWh because solar adds curtailment.
+    expect(region.totalTWh).toBeGreaterThan(windOnly.totalTWh);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// entsoe: buildZoneData
+// ---------------------------------------------------------------------------
+
+describe("buildZoneData — two-sided generation", () => {
+  const RAW_MW = 5000; // raw A75 generation in MW
+  const RATE = 0.08;   // 8% curtailment rate
+  const rawPoints = makeRawPoints(RAW_MW);
+
+  const region = buildZoneData("test-zone", rawPoints, RATE, "Test ENTSO-E zone");
+
+  it("emits generationProfile of length 24", () => {
+    expect(region.generationProfile).toBeDefined();
+    expect(region.generationProfile!.length).toBe(24);
+  });
+
+  it("generationProfile values are all non-negative", () => {
+    expect(region.generationProfile!.every((v) => v >= 0)).toBe(true);
+  });
+
+  it("emits generationTotalTWh", () => {
+    expect(region.generationTotalTWh).toBeDefined();
+    expect(typeof region.generationTotalTWh).toBe("number");
+  });
+
+  it("generationTotalTWh >= totalTWh", () => {
+    expect(region.generationTotalTWh!).toBeGreaterThanOrEqual(region.totalTWh);
+  });
+
+  it("generationTotalTWh is approximately totalTWh / rate", () => {
+    expect(region.generationTotalTWh!).toBeCloseTo(region.totalTWh / RATE, 5);
+  });
+
+  it("generationProfile GW > profile GW at each hour (generation > curtailment)", () => {
+    // At a sub-100% rate, generation > curtailment at every hour that has data.
+    for (let h = 0; h < 24; h++) {
+      expect(region.generationProfile![h]).toBeGreaterThanOrEqual(region.profile[h]);
+    }
+  });
+
+  it("totalTWh (curtailment) is unchanged compared to pre-generation-field value", () => {
+    // Confirms additive-only: we can recompute what totalTWh must be.
+    const expectedCurtailmentTWh = (RAW_MW * RATE * rawPoints.length) / 1_000_000;
+    expect(region.totalTWh).toBeCloseTo(expectedCurtailmentTWh, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// entsoe: buildZoneData with fuelShare — generation fields still present
+// ---------------------------------------------------------------------------
+
+describe("buildZoneData with fuelShare — generation fields present", () => {
+  const rawPoints = makeRawPoints(3000);
+  const fuelShare = { wind: 0.6, solar: 0.4 };
+  const region = buildZoneData("test-zone-multi", rawPoints, 0.12, "Multi-fuel zone", fuelShare);
+
+  it("generationProfile still emitted when fuelShare is provided", () => {
+    expect(region.generationProfile).toBeDefined();
+    expect(region.generationProfile!.length).toBe(24);
+  });
+
+  it("generationTotalTWh >= totalTWh with fuelShare", () => {
+    expect(region.generationTotalTWh!).toBeGreaterThanOrEqual(region.totalTWh);
+  });
+});


### PR DESCRIPTION
Populates the long-reserved `generationProfile` / `generationTotalTWh` fields on `RegionData` from the gross renewable generation the loaders already fetch — so the dataset documents BOTH generation and the curtailment derived from it. **Purely additive**: no curtailment value, tier, region, golden, or headline aggregate changes.

- `src/lib/eia-iso.ts` — attaches generation (pre-×-rate WND/SUN series) on both the per-fuel and aggregate build paths (~17 US ISO/BA regions).
- `src/lib/entsoe.ts` — attaches generation from the A75 series on `buildZoneData` + `fetchEntsoeZone` (~40+ European zones).
- `dataset/schema/region-snapshot.schema.json` — adds the two fields as **optional** (`additionalProperties:false` preserved; all 274 existing snapshots still validate). Invariant documented: `generationTotalTWh ≥ totalTWh` (can't curtail more than generated).
- `tests/two-sided-generation.test.ts` — 22 assertions; verifies the invariant on every path.

Snapshots are **not** regenerated here (avoids API-token deps in CI); the fields populate in prod on the next live build. Verified: `tsc` clean · **1003 tests** · `ci:gates` green · `validate` clean (the agent ran these in-worktree; diff reviewed for additive-only scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)